### PR TITLE
Crear NavGraph centralizado con rutas tipadas

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED_PARAMETER")
+
 package com.marlon.portalusuario.navigation
 
 import androidx.compose.foundation.layout.Box
@@ -7,10 +9,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 
+/**
+ * NavHost centralizado con todas las rutas de la aplicación.
+ * Cada ruta se mapea a su composable correspondiente.
+ * Las rutas con argumentos tipados extraen los valores del [NavBackStackEntry].
+ */
 @Composable
 fun PortalUsuarioNavHost(
     navController: NavHostController = rememberNavController(),
@@ -32,12 +41,26 @@ fun PortalUsuarioNavHost(
         composable(Route.Voz.route) { PlaceholderScreen("Voz") }
         composable(Route.PlanAmigos.route) { PlaceholderScreen("Plan Amigos") }
         composable(Route.PrivateCall.route) { PlaceholderScreen("Private Call") }
-        composable(Route.CallForReverseCharge.route) { PlaceholderScreen("Call for Reverse Charge") }
+        composable(Route.CallForReverseCharge.route) {
+            PlaceholderScreen("Call for Reverse Charge")
+        }
         composable(Route.EmergencyCalls.route) { PlaceholderScreen("Emergency Calls") }
         composable(Route.Une.route) { PlaceholderScreen("UNE") }
         composable(Route.Perfil.route) { PlaceholderScreen("Perfil") }
         composable(Route.LogFileViewer.route) { PlaceholderScreen("Log File Viewer") }
-        composable(Route.PUNotifications.route) { PlaceholderScreen("PU Notifications") }
+        composable(
+            route = Route.PUNotifications.route,
+            arguments =
+                listOf(
+                    navArgument("notificationId") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    },
+                ),
+        ) { backStackEntry ->
+            val notificationId = backStackEntry.arguments?.getString("notificationId") ?: ""
+            PlaceholderScreen("PU Notifications (id=$notificationId)")
+        }
     }
 }
 

--- a/app/src/main/java/com/marlon/portalusuario/navigation/Route.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Route.kt
@@ -1,39 +1,87 @@
 package com.marlon.portalusuario.navigation
 
-sealed class Route(val route: String) {
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+
+/**
+ * Definición centralizada de todas las rutas de navegación de la aplicación.
+ *
+ * Cada ruta define su patrón de URL y los argumentos tipados que espera.
+ * Usar [createRoute] para navegar a rutas con argumentos opcionales.
+ */
+sealed class Route(
+    val route: String,
+    val arguments: List<NamedNavArgument> = emptyList(),
+) {
+    /** Pantalla de splash / carga inicial */
     data object Splash : Route("splash")
 
+    /** Onboarding / tutorial inicial */
     data object Intro : Route("intro")
 
+    /** Solicitud de permisos esenciales */
     data object Permissions : Route("permissions")
 
+    /** Pantalla principal con drawer de navegación */
     data object Main : Route("main")
 
+    /** Configuración de la aplicación */
     data object Settings : Route("settings")
 
+    /** Información de la aplicación */
     data object About : Route("about")
 
+    /** Donaciones / apoyo */
     data object Donation : Route("donation")
 
+    /** Política de privacidad */
     data object Privacy : Route("privacy")
 
+    /** Servicio de mensajería SMS */
     data object Sms : Route("sms")
 
+    /** Servicio de llamadas de voz */
     data object Voz : Route("voz")
 
+    /** Plan Amigos */
     data object PlanAmigos : Route("plan_amigos")
 
+    /** Llamada privada */
     data object PrivateCall : Route("private_call")
 
+    /** Llamada por cobrar */
     data object CallForReverseCharge : Route("call_for_reverse_charge")
 
+    /** Llamadas de emergencia */
     data object EmergencyCalls : Route("emergency_calls")
 
+    /** Consumo eléctrico (UNE) */
     data object Une : Route("une")
 
+    /** Perfil del usuario */
     data object Perfil : Route("perfil")
 
+    /** Visor de logs de depuración */
     data object LogFileViewer : Route("log_file_viewer")
 
-    data object PUNotifications : Route("pu_notifications")
+    /** Notificaciones de Portal Usuario */
+    data object PUNotifications : Route(
+        route = "pu_notifications?notificationId={notificationId}",
+        arguments =
+            listOf(
+                navArgument("notificationId") {
+                    type = NavType.StringType
+                    defaultValue = ""
+                },
+            ),
+    ) {
+        /** Crea una ruta a notificaciones, opcionalmente con un ID específico. */
+        fun createRoute(notificationId: String? = null): String =
+            if (notificationId != null) {
+                "pu_notifications?notificationId=$notificationId"
+            } else {
+                "pu_notifications"
+            }
+    }
 }


### PR DESCRIPTION
Sistema de navegación centralizado usando Navigation Compose con rutas tipadas (Fase 2).

**Cambios en Route.kt:**
- Sealed class Route con argumentos tipados via NamedNavArgument
- Ruta PUNotifications con argumento opcional notificationId (NavType.StringType)
- Metodo createRoute() para rutas con argumentos opcionales
- KDoc documentando cada ruta

**Cambios en Navigation.kt:**
- PortalUsuarioNavHost actualizado para extraer argumentos tipados del NavBackStackEntry
- Definicion de navArgument para notificationId en PUNotifications
- PlaceholderScreen temporal mientras se migran las pantallas reales

**Proximos pasos:**
- Conectar cada ruta con su Screen composable real
- Migrar actividades actuales a destinos Navigation Compose

Closes #216