### PR TITLE
Reemplazar startActivity() con navController.navigate()

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -15,8 +15,14 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.marlon.portalusuario.paquetes.PaquetesScreen
+import com.marlon.portalusuario.perfil.PerfilScreen
+import com.marlon.portalusuario.presentation.about.AboutScreen
+import com.marlon.portalusuario.presentation.donation.DonationScreen
 import com.marlon.portalusuario.presentation.mobileservices.screen.MobileServicesScreen
+import com.marlon.portalusuario.presentation.privacy.PrivacyScreen
+import com.marlon.portalusuario.presentation.settings.SettingsScreen
 import com.marlon.portalusuario.servicios.ServiciosScreen
+import com.marlon.portalusuario.une.UneScreen
 
 /**
  * NavHost centralizado con todas las rutas de la aplicación.
@@ -38,10 +44,10 @@ fun PortalUsuarioNavHost(
         composable(Route.Intro.route) { PlaceholderScreen("Intro") }
         composable(Route.Permissions.route) { PlaceholderScreen("Permissions") }
         composable(Route.Main.route) { MobileServicesScreen() }
-        composable(Route.Settings.route) { PlaceholderScreen("Settings") }
-        composable(Route.About.route) { PlaceholderScreen("About") }
-        composable(Route.Donation.route) { PlaceholderScreen("Donation") }
-        composable(Route.Privacy.route) { PlaceholderScreen("Privacy") }
+        composable(Route.Settings.route) { SettingsScreen() }
+        composable(Route.About.route) { AboutScreen() }
+        composable(Route.Donation.route) { DonationScreen() }
+        composable(Route.Privacy.route) { PrivacyScreen() }
         composable(Route.Sms.route) { PlaceholderScreen("Sms") }
         composable(Route.Voz.route) { PlaceholderScreen("Voz") }
         composable(Route.PlanAmigos.route) { PlaceholderScreen("Plan Amigos") }
@@ -50,8 +56,10 @@ fun PortalUsuarioNavHost(
             PlaceholderScreen("Call for Reverse Charge")
         }
         composable(Route.EmergencyCalls.route) { PlaceholderScreen("Emergency Calls") }
-        composable(Route.Une.route) { PlaceholderScreen("UNE") }
-        composable(Route.Perfil.route) { PlaceholderScreen("Perfil") }
+        composable(Route.Une.route) {
+            UneScreen(onBack = { navController.popBackStack() })
+        }
+        composable(Route.Perfil.route) { PerfilScreen() }
         composable(Route.Servicios.route) { ServiciosScreen() }
         composable(Route.Paquetes.route) { PaquetesScreen() }
         composable(Route.LogFileViewer.route) { PlaceholderScreen("Log File Viewer") }

--- a/app/src/main/java/com/marlon/portalusuario/presentation/about/AboutScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/presentation/about/AboutScreen.kt
@@ -1,0 +1,121 @@
+package com.marlon.portalusuario.presentation.about
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AboutScreen() {
+    val context = LocalContext.current
+    val versionName =
+        try {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName
+        } catch (_: PackageManager.NameNotFoundException) {
+            "?"
+        }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = "Portal Usuario",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "Versión $versionName",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Acerca de",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text =
+                "Portal Usuario es una aplicación que te permite gestionar tus servicios " +
+                    "móviles en Cuba de forma rápida y sencilla.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Redes del desarrollador",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SocialLinkCard("Facebook", "https://facebook.com/javyalejandro99")
+        SocialLinkCard("Instagram", "https://www.instagram.com/jalexoasismusic")
+        SocialLinkCard("Twitter", "https://twitter.com/javyalejandro99")
+        SocialLinkCard("Telegram", "https://t.me/jalexcode")
+        SocialLinkCard("GitHub", "https://github.com/jalexcode")
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Descargar desde",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SocialLinkCard("Google Play", "https://play.google.com/store/apps/details?id=com.marlon.portalusuario")
+        SocialLinkCard("Apklis", "https://www.apklis.cu/application/com.marlon.portalusuario")
+        SocialLinkCard("APKPure", "https://m.apkpure.com/es/portal-usuario/com.marlon.portalusuario")
+    }
+}
+
+@Composable
+private fun SocialLinkCard(
+    label: String,
+    url: String,
+) {
+    val context = LocalContext.current
+
+    Card(
+        onClick = {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        },
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/app/src/main/java/com/marlon/portalusuario/presentation/donation/DonationScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/presentation/donation/DonationScreen.kt
@@ -1,0 +1,163 @@
+package com.marlon.portalusuario.presentation.donation
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+
+@Composable
+fun DonationScreen() {
+    val context = LocalContext.current
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = "Donar al proyecto",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Colabora con el desarrollo de Portal Usuario. Las transferencias se realizan vía USSD.",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        DonationCard(
+            title = "Transferencia a Javier A. (54871663)",
+            onDonate = { amount, password ->
+                launchCall(context, "54871663", amount, password)
+            },
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        DonationCard(
+            title = "Transferencia a Yasmany (58076608)",
+            onDonate = { amount, password ->
+                launchCall(context, "58076608", amount, password)
+            },
+        )
+    }
+}
+
+@Composable
+private fun DonationCard(
+    title: String,
+    onDonate: (String, String) -> Unit,
+) {
+    val context = LocalContext.current
+    var amount by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = amount,
+                onValueChange = { amount = it },
+                label = { Text("Monto") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Contraseña") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = {
+                    if (amount.isBlank() || password.isBlank()) {
+                        Toast.makeText(
+                            context,
+                            "Todos los campos son obligatorios",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    } else {
+                        onDonate(amount, password)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Transferir")
+            }
+        }
+    }
+}
+
+private fun launchCall(
+    context: android.content.Context,
+    phoneNumber: String,
+    amount: String,
+    password: String,
+) {
+    val intent =
+        Intent(Intent.ACTION_CALL).apply {
+            data = Uri.parse("tel:*234*1*$phoneNumber*$amount*$password%23")
+        }
+    if (ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.CALL_PHONE,
+        ) == PackageManager.PERMISSION_GRANTED
+    ) {
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/marlon/portalusuario/presentation/privacy/PrivacyScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/presentation/privacy/PrivacyScreen.kt
@@ -1,0 +1,24 @@
+package com.marlon.portalusuario.presentation.privacy
+
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun PrivacyScreen() {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { context ->
+            WebView(context).apply {
+                webViewClient = WebViewClient()
+                settings.javaScriptEnabled = true
+                loadUrl("https://portalusuarioapp.blogspot.com/p/portal-usuario-mas-que-una-simple.html")
+            }
+        },
+    )
+}


### PR DESCRIPTION
Closes #220

- Wire SettingsScreen(), UneScreen(), PerfilScreen() en NavHost
- Crear AboutScreen, DonationScreen, PrivacyScreen como composables
- Eliminar PlaceholderScreen para rutas con screens reales