### PR TITLE
feat: agregar componentes reutilizables LoadingState, ErrorState, EmptyState (#230)

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreen.kt
@@ -29,6 +29,7 @@ import com.marlon.portalusuario.feature.mobileservices.presentation.components.M
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.PlansSection
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.configsimcards.ConfigSimCardsBottomSheet
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.servsettings.ServiceSettingsBottomSheet
+import com.marlon.portalusuario.ui.components.EmptyState
 import com.marlon.portalusuario.ui.components.ErrorDialog
 import io.github.suitetecsa.sdk.android.model.SimCard
 
@@ -49,13 +50,15 @@ fun MobileServicesScreen(viewModel: MobileServicesViewModel = hiltViewModel()) {
             Modifier
                 .fillMaxSize(),
     ) {
-        mobServices.takeIf { it.isNotEmpty() }?.let { services ->
+        if (mobServices.isEmpty()) {
+            EmptyState(message = "No hay servicios móviles disponibles")
+        } else {
             val serviceId =
-                preferences.mssId ?: services.first().id.also {
+                preferences.mssId ?: mobServices.first().id.also {
                     viewModel.onEvent(MobileServicesEvent.OnChangeCurrentMobileService(it))
                 }
             ScreenContent(
-                services = services,
+                services = mobServices,
                 currentServiceId = serviceId,
                 state = viewModel.state.value,
                 onEvent = viewModel::onEvent,

--- a/app/src/main/java/com/marlon/portalusuario/ui/components/EmptyState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/ui/components/EmptyState.kt
@@ -1,0 +1,76 @@
+package com.marlon.portalusuario.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Inbox
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+
+@Composable
+fun EmptyState(
+    message: String,
+    modifier: Modifier = Modifier,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Inbox,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        if (actionLabel != null && onAction != null) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onAction) {
+                Text(actionLabel)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyStatePreview() {
+    PortalUsuarioTheme {
+        EmptyState(
+            message = "No hay elementos disponibles.",
+            actionLabel = "Recargar",
+            onAction = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyStateNoActionPreview() {
+    PortalUsuarioTheme {
+        EmptyState(message = "No hay elementos disponibles.")
+    }
+}

--- a/app/src/main/java/com/marlon/portalusuario/ui/components/ErrorState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/ui/components/ErrorState.kt
@@ -1,0 +1,74 @@
+package com.marlon.portalusuario.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+
+@Composable
+fun ErrorState(
+    message: String,
+    modifier: Modifier = Modifier,
+    onRetry: (() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        if (onRetry != null) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onRetry) {
+                Text("Reintentar")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ErrorStatePreview() {
+    PortalUsuarioTheme {
+        ErrorState(
+            message = "Ocurrió un error al cargar los datos.",
+            onRetry = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ErrorStateNoRetryPreview() {
+    PortalUsuarioTheme {
+        ErrorState(message = "Ocurrió un error al cargar los datos.")
+    }
+}

--- a/app/src/main/java/com/marlon/portalusuario/ui/components/LoadingState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/ui/components/LoadingState.kt
@@ -1,0 +1,58 @@
+package com.marlon.portalusuario.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+
+@Composable
+fun LoadingState(
+    modifier: Modifier = Modifier,
+    message: String? = null,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(48.dp),
+            color = MaterialTheme.colorScheme.primary,
+        )
+        if (message != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoadingStatePreview() {
+    PortalUsuarioTheme {
+        LoadingState(message = "Cargando...")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoadingStateNoMessagePreview() {
+    PortalUsuarioTheme {
+        LoadingState()
+    }
+}

--- a/app/src/main/java/com/marlon/portalusuario/une/UneScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/une/UneScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.marlon.portalusuario.ui.components.EmptyState
+import com.marlon.portalusuario.ui.components.ErrorState
 import com.marlon.portalusuario.ui.theme.VibrantGreen
 import com.marlon.portalusuario.util.Util
 import com.marlon.portalusuario.viewmodel.UneViewModel
@@ -193,10 +195,8 @@ fun UneScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             if (allUnes.isEmpty()) {
-                Text(
-                    text = "No hay registros aún",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 16.dp),
+                EmptyState(
+                    message = "No hay registros aún",
                 )
             } else {
                 LazyColumn(


### PR DESCRIPTION
## Cambios

- Crear `LoadingState` composable con `CircularProgressIndicator` y mensaje opcional
- Crear `ErrorState` composable con icono, mensaje y botón de reintento opcional
- Crear `EmptyState` composable con icono, mensaje y acción opcional
- Refactorizar `MobileServicesScreen` para usar `EmptyState`
- Refactorizar `UneScreen` para usar `EmptyState`

Closes #230