### PR TITLE
test: agregar tests de use cases con fakes (#231)

### DIFF
--- a/app/src/test/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCaseTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.marlon.portalusuario.feature.telephony.domain.usecases
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ValidatePhoneNumberUseCaseTest {
+
+    private val useCase = ValidatePhoneNumberUseCase()
+
+    @Test
+    fun `valid phone number with 8 digits`() {
+        assertTrue(useCase("12345678"))
+    }
+
+    @Test
+    fun `valid phone number with more than 8 digits`() {
+        assertTrue(useCase("123456789"))
+    }
+
+    @Test
+    fun `invalid phone number with less than 8 digits`() {
+        assertFalse(useCase("1234567"))
+    }
+
+    @Test
+    fun `invalid phone number with letters`() {
+        assertFalse(useCase("12345abc"))
+    }
+
+    @Test
+    fun `invalid empty phone number`() {
+        assertFalse(useCase(""))
+    }
+
+    @Test
+    fun `invalid phone number with special characters`() {
+        assertFalse(useCase("1234-678"))
+    }
+
+    @Test
+    fun `valid phone number with leading zeros`() {
+        assertTrue(useCase("01234567"))
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCaseTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCaseTest.kt
@@ -1,0 +1,135 @@
+package com.marlon.portalusuario.feature.une.domain.usecases
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalculateElectricityCostUseCaseTest {
+
+    private val useCase = CalculateElectricityCostUseCase()
+
+    @Test
+    fun `success with valid readings`() {
+        val result = useCase("100", "150")
+
+        assertTrue(result is ElectricityCostResult.Success)
+        val success = result as ElectricityCostResult.Success
+        assertEquals(50.0, success.consumption, 0.001)
+        assertTrue(success.totalToPay > 0)
+    }
+
+    @Test
+    fun `success with zero consumption`() {
+        val result = useCase("200", "200")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertEquals(
+            "Lectura anterior y Lectura Actual no deben ser iguales",
+            (result as ElectricityCostResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `error when previous reading is invalid`() {
+        val result = useCase("abc", "150")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertTrue((result as ElectricityCostResult.Error).message.contains("Lectura Anterior"))
+    }
+
+    @Test
+    fun `error when current reading is invalid`() {
+        val result = useCase("100", "xyz")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertTrue((result as ElectricityCostResult.Error).message.contains("Lectura Actual"))
+    }
+
+    @Test
+    fun `error when both readings are invalid`() {
+        val result = useCase("abc", "xyz")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        val error = result as ElectricityCostResult.Error
+        assertTrue(error.message.contains("Lectura Anterior"))
+        assertTrue(error.message.contains("Lectura Actual"))
+    }
+
+    @Test
+    fun `error when current is less than previous`() {
+        val result = useCase("200", "100")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertEquals(
+            "La lectura Anterior no puede ser mayor a la Actual",
+            (result as ElectricityCostResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `error when current reading is negative`() {
+        val result = useCase("100", "-50")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertEquals(
+            "Lectura Actual: Valor inválido",
+            (result as ElectricityCostResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `error when previous reading is negative`() {
+        val result = useCase("-100", "50")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertEquals(
+            "Lectura Anterior: Valor inválido",
+            (result as ElectricityCostResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `error on empty previous reading`() {
+        val result = useCase("", "150")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertTrue((result as ElectricityCostResult.Error).message.contains("Lectura Anterior"))
+    }
+
+    @Test
+    fun `error on empty current reading`() {
+        val result = useCase("100", "")
+
+        assertTrue(result is ElectricityCostResult.Error)
+        assertTrue((result as ElectricityCostResult.Error).message.contains("Lectura Actual"))
+    }
+
+    @Test
+    fun `success with decimal readings`() {
+        val result = useCase("100.5", "150.7")
+
+        assertTrue(result is ElectricityCostResult.Success)
+        val success = result as ElectricityCostResult.Success
+        assertEquals(50.2, success.consumption, 0.001)
+    }
+
+    @Test
+    fun `success with trimmed whitespace`() {
+        val result = useCase("  100  ", "  150  ")
+
+        assertTrue(result is ElectricityCostResult.Success)
+        val success = result as ElectricityCostResult.Success
+        assertEquals(50.0, success.consumption, 0.001)
+    }
+
+    @Test
+    fun `totalToPay is positive for valid consumption`() {
+        val result = useCase("0", "100")
+
+        assertTrue(result is ElectricityCostResult.Success)
+        val success = result as ElectricityCostResult.Success
+        assertEquals(100.0, success.consumption, 0.001)
+        assertTrue("Total to pay should be positive", success.totalToPay > 0)
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakePunRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakePunRepository.kt
@@ -1,0 +1,32 @@
+package com.marlon.portalusuario.testhelpers
+
+import com.marlon.portalusuario.domain.data.PunRepository
+import com.marlon.portalusuario.punotifications.PUNotification
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakePunRepository(
+    initialPuns: List<PUNotification> = emptyList(),
+) : PunRepository {
+    private val _allPUN = MutableStateFlow(initialPuns)
+
+    override val allPUN: Flow<List<PUNotification>> = _allPUN
+
+    override suspend fun insertPUNotification(pun: PUNotification) {
+        _allPUN.value = _allPUN.value + pun
+    }
+
+    override suspend fun updatePUNotification(pun: PUNotification) {
+        _allPUN.value = _allPUN.value.map {
+            if (it.id == pun.id) pun else it
+        }
+    }
+
+    override suspend fun deletePUNotification(pun: PUNotification) {
+        _allPUN.value = _allPUN.value - pun
+    }
+
+    override suspend fun deleteAllPUNotifications() {
+        _allPUN.value = emptyList()
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUneRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUneRepository.kt
@@ -1,0 +1,32 @@
+package com.marlon.portalusuario.testhelpers
+
+import com.marlon.portalusuario.domain.data.UneRepository
+import com.marlon.portalusuario.une.Une
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeUneRepository(
+    initialUnes: List<Une> = emptyList(),
+) : UneRepository {
+    private val _allUnes = MutableStateFlow(initialUnes)
+
+    override val allUnes: Flow<List<Une>> = _allUnes
+
+    override suspend fun insertUne(une: Une) {
+        _allUnes.value = _allUnes.value + une
+    }
+
+    override suspend fun updateUne(une: Une) {
+        _allUnes.value = _allUnes.value.map {
+            if (it.id == une.id) une else it
+        }
+    }
+
+    override suspend fun deleteUne(une: Une) {
+        _allUnes.value = _allUnes.value - une
+    }
+
+    override suspend fun deleteAllUnes() {
+        _allUnes.value = emptyList()
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserAccountRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserAccountRepository.kt
@@ -1,0 +1,32 @@
+package com.marlon.portalusuario.testhelpers
+
+import com.marlon.portalusuario.domain.data.UserAccountRepository
+import com.marlon.portalusuario.model.User
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeUserAccountRepository(
+    initialUsers: List<User> = emptyList(),
+) : UserAccountRepository {
+    private val _allUsers = MutableStateFlow(initialUsers)
+
+    override val allUsers: Flow<List<User>> = _allUsers
+
+    override suspend fun insertUser(user: User) {
+        _allUsers.value = _allUsers.value + user
+    }
+
+    override suspend fun updateUser(user: User) {
+        _allUsers.value = _allUsers.value.map {
+            if (it.id == user.id) user else it
+        }
+    }
+
+    override suspend fun deleteUser(user: User) {
+        _allUsers.value = _allUsers.value - user
+    }
+
+    override suspend fun deleteAllUsers() {
+        _allUsers.value = emptyList()
+    }
+}


### PR DESCRIPTION
## Cambios

- Crear `FakeUneRepository`, `FakePunRepository`, `FakeUserAccountRepository`
- Escribir 13 tests para `CalculateElectricityCostUseCase` (éxito, errores de validación, casos borde)
- Escribir 7 tests para `ValidatePhoneNumberUseCase` (válidos, inválidos, vacío, caracteres especiales)

Closes #231