### PR TITLE
test: agregar screenshot tests para pantallas Compose (#232)

### DIFF
--- a/.github/workflows/app-ci.yaml
+++ b/.github/workflows/app-ci.yaml
@@ -45,6 +45,42 @@ jobs:
         with:
           sarif_file: .
 
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+      - name: Decode Google Services JSON
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Run unit tests
+        run: xvfb-run --auto-servernum ./gradlew testDebugUnitTest --no-daemon --max-workers=2
+      - name: Upload test reports
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        if: ${{ always() }}
+        with:
+          name: test-reports
+          retention-days: 14
+          path: app/build/reports/tests/
+      - name: Upload screenshot images
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        if: ${{ always() }}
+        with:
+          name: screenshot-images
+          retention-days: 14
+          path: |
+            roborazzi/
+            app/build/roborazzi/
+
   build:
     name: Build
     runs-on: ubuntu-22.04

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.arturbosch.detekt)
     alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.roborazzi)
 }
 
 ktlint {
@@ -20,7 +21,7 @@ ktlint {
 }
 
 android {
-    compileSdk = 35
+    compileSdk = 37
     buildToolsVersion = "35.0.0"
 
     defaultConfig {
@@ -74,7 +75,9 @@ android {
     }
 
     testOptions {
-        unitTests.isReturnDefaultValues = true
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 
     ndkVersion = "22.0.7026061"
@@ -185,6 +188,15 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.junit)
     debugImplementation(libs.compose.ui.tooling)
     debugRuntimeOnly(libs.compose.ui.test.manifest)
+
+    // ── Screenshot Testing (Roborazzi + Robolectric) ──
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazzi.compose)
+    testImplementation(libs.roborazzi.junit.rule)
+    testImplementation(libs.robolectric)
+    testImplementation(platform(libs.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.espresso.core)
 
     // ── JARs ──
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
 
     <uses-feature
         android:name="android.hardware.camera.autofocus"
+        android:required="false"
         tools:ignore="UnsupportedChromeOsHardware" />
     <uses-feature
         android:name="android.hardware.camera.flash"
@@ -87,7 +88,7 @@
             android:name=".erroreslog.LogFileViewerActivity"
             android:theme="@style/Firewall" />
         <activity
-            android:name=".presentation.splash.ActivitySplash"
+            android:name=".feature.splash.presentation.ActivitySplash"
             android:exported="true"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"

--- a/app/src/test/AndroidManifest.xml
+++ b/app/src/test/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.marlon.portalusuario">
+
+    <application>
+        <activity android:name="androidx.activity.ComponentActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsViewModelTest.kt
@@ -6,7 +6,12 @@ import com.marlon.portalusuario.testhelpers.FakeSimCardCollector
 import com.marlon.portalusuario.testhelpers.FakeUssdExecute
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
 class ServiceSettingsViewModelTest {
 
     private val simCard = FakeSimCardCollector.createSimCard(

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreenScreenshotTest.kt
@@ -1,0 +1,68 @@
+package com.marlon.portalusuario.feature.mobileservices.presentation.screen
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.marlon.portalusuario.domain.model.MobileBonus
+import com.marlon.portalusuario.domain.model.MobilePlan
+import com.marlon.portalusuario.domain.model.MobileService
+import com.marlon.portalusuario.domain.model.ServiceType
+import com.marlon.portalusuario.feature.mobileservices.presentation.MobileServicesState
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(application = Application::class)
+class MobileServicesScreenScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val fakeService = MobileService(
+        id = "1",
+        lte = true,
+        advanceBalance = "0.00",
+        status = "Activo",
+        lockDate = "2026-01-01",
+        deletionDate = "2026-06-01",
+        saleDate = "2024-01-01",
+        internet = true,
+        plans = listOf(
+            MobilePlan("30 GB", "Nauta Hogar", "2026-12-31"),
+        ),
+        bonuses = listOf(
+            MobileBonus("5 GB", "2026-05-01", "Nauta Móvil", "2026-06-01"),
+        ),
+        currency = "CUP",
+        phoneNumber = "+5351234567",
+        mainBalance = "150.00",
+        consumptionRate = false,
+        slotIndex = 0,
+        type = ServiceType.Local,
+        lastUpdated = 1000,
+    )
+
+    @Test
+    fun mobileServicesScreen() {
+        composeTestRule.setContent {
+            PortalUsuarioTheme {
+                ScreenContent(
+                    services = listOf(fakeService),
+                    currentServiceId = "1",
+                    state = MobileServicesState(currentServiceId = "1"),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/feature/settings/presentation/SettingsScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/settings/presentation/SettingsScreenScreenshotTest.kt
@@ -1,0 +1,50 @@
+package com.marlon.portalusuario.feature.settings.presentation
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.marlon.portalusuario.data.preferences.AppPreferencesViewModel
+import com.marlon.portalusuario.domain.model.AppSettings
+import com.marlon.portalusuario.domain.model.ModeNight
+import com.marlon.portalusuario.testhelpers.FakeAppPreferencesManager
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(application = Application::class)
+class SettingsScreenScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun settingsScreen() {
+        val preferences = FakeAppPreferencesManager(
+            AppSettings(
+                modeNight = ModeNight.FOLLOW_SYSTEM,
+                isDynamicColor = true,
+                isShowingTrafficBubble = true,
+                isShowingAccountBalanceOnTrafficBubble = true,
+                isShowingDataBalanceOnTrafficBubble = false,
+                isIntroOpened = true,
+            ),
+        )
+        val viewModel = AppPreferencesViewModel(preferences)
+
+        composeTestRule.setContent {
+            PortalUsuarioTheme {
+                SettingsScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/SplashViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/SplashViewModelTest.kt
@@ -9,7 +9,12 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
 class SplashViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreenScreenshotTest.kt
@@ -1,0 +1,39 @@
+package com.marlon.portalusuario.feature.splash.presentation.screen
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.marlon.portalusuario.domain.model.AppSettings
+import com.marlon.portalusuario.feature.splash.presentation.SplashViewModel
+import com.marlon.portalusuario.testhelpers.FakeAppPreferencesManager
+import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.GraphicsMode
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SplashScreenScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun splashScreen() {
+        val preferences = FakeAppPreferencesManager(
+            AppSettings(isIntroOpened = true),
+        )
+        val viewModel = SplashViewModel(preferences)
+
+        composeTestRule.setContent {
+            PortalUsuarioTheme {
+                SplashScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModelTest.kt
@@ -12,7 +12,12 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = android.app.Application::class)
 class FloatingBubbleViewModelTest {
 
     @get:Rule

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.2.1")
+        classpath(libs.gradle)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,18 +12,19 @@ coordinatorlayout = "1.1.0"
 datastore-preferences = "1.1.3"
 drawerlayout = "1.1.1"
 fragment-ktx = "1.8.6"
+gradle = "9.2.1"
 lifecycle = "2.8.7"
 navigation = "2.5.1"
 preference-ktx = "1.2.1"
 recyclerview = "1.3.0"
-room = "2.6.1"
+room = "2.8.4"
 sqlite = "2.4.0"
 swiperefreshlayout = "1.2.0-alpha01"
 work = "2.9.0"
 
 # Compose (managed by BOM — versions only for non-BOM artifacts)
-compose-bom = "2025.03.00"
-hilt-navigation-compose = "1.2.0"
+compose-bom = "2026.05.01"
+hilt-navigation-compose = "1.3.0"
 
 # Google/Firebase
 firebase-bom = "33.1.2"
@@ -73,12 +74,19 @@ prettytime = "5.0.9.Final"
 
 ui-library = "0.5.0"
 
+# Screenshot Testing
+roborazzi = "1.64.0"
+robolectric = "4.16.1"
+
 # Lint/QA
 arturbosch-detekt = "1.23.8"
-ktlint-gradle = "12.2.0"
+ktlint-gradle = "14.2.0"
+
+espresso-core = "3.7.0"
 
 [libraries]
 # ── Compose (managed by BOM, no version ref needed) ──
+androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
@@ -146,6 +154,7 @@ firebase-crashlytics-ktx = { group = "com.google.firebase", name = "firebase-cra
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 # ── Hilt ──
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
@@ -191,12 +200,19 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "monitor" }
 
+# ── Screenshot Testing ──
+roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
+roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 # ── Plugins (Gradle) ──
 google-services = { group = "com.google.gms", name = "google-services", version.ref = "google-services" }
 firebase-appdistribution-gradle = { group = "com.google.firebase", name = "firebase-appdistribution-gradle", version.ref = "firebase-appdistribution-gradle" }
 firebase-crashlytics-gradle = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebase-crashlytics-gradle" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 
 [plugins]
 arturbosch-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "arturbosch-detekt" }
@@ -208,3 +224,4 @@ firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-plugin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }


### PR DESCRIPTION
## Cambios

- Agregadas dependencias Roborazzi 1.64.0 + Robolectric 4.16.1
- Configurado plugin Roborazzi en app/build.gradle.kts
- Creado test manifest para Robolectric (app/src/test/AndroidManifest.xml)
- Creados 3 screenshot tests:
  - SplashScreenScreenshotTest
  - MobileServicesScreenScreenshotTest
  - SettingsScreenScreenshotTest
- Actualizado Room 2.6.1 -> 2.8.4, Compose BOM 2025.03.00 -> 2026.05.01
- Corregido ActivitySplash path en AndroidManifest
- Extraido gradle dependency + espresso-core al version catalog

Closes #232