### PR TITLE
chore: configurar CI completo con lint + test + detekt (#234)

### DIFF
--- a/.github/workflows/app-ci.yaml
+++ b/.github/workflows/app-ci.yaml
@@ -8,35 +8,39 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m"
+
 jobs:
-  avoid_reduncy:
-    runs-on: ubuntu-22.04
+  cancel-redundant:
+    runs-on: ubuntu-24.04
     steps:
-      - name: Cancel Previous Redundant Builds
+      - name: Cancel previous redundant builds
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
-    continue-on-error: true
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         task: [ detekt, lint, ktlintCheck ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Java
+      - name: Setup Java 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
-      - name: Run ${{ matrix.task }} task
+      - name: Run ${{ matrix.task }}
         run: ./gradlew ${{ matrix.task }}
       - name: Upload SARIF files
         uses: github/codeql-action/upload-sarif@2c779ab0d087cd7fe7b826087247c2c81f27bfa6 # v3.26.5
@@ -47,17 +51,19 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Java
+      - name: Setup Java 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
       - name: Install xvfb
@@ -83,17 +89,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Java
+      - name: Setup Java 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON
         run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
       - name: Assemble debug APKs
@@ -107,4 +115,3 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path: build/gh-app-publish/
-    

--- a/.github/workflows/gradlew-validate.yaml
+++ b/.github/workflows/gradlew-validate.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     paths:
-      - '**/gradlе-wrapper.jar'
+      - '**/gradle-wrapper.jar'
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 android.useBuildCache=true
-org.gradle.java.home=/home/lesclaz/APPs/android-studio/jbr
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.enableJetifier=true
 org.gradle.caching=true


### PR DESCRIPTION
## Cambios

### Workflow `app-ci.yaml` actualizado:
- **Java 17 → 21** (Gradle 9.4.1 lo requiere)
- **`gradle-build-action` → `gradle/actions/setup-gradle@v4`** (acción oficial, mejor caching)
- **`continue-on-error: true` eliminado** del job lint (ahora falla si hay errores)
- **`ubuntu-22.04` → `ubuntu-24.04`** (LTS más reciente)
- Caching condicional: solo escritura en master

### `gradle.properties`:
- Eliminado `org.gradle.java.home` (ruta local del desarrollador, rompía CI). Configurar `JAVA_HOME` localmente o en `~/.gradle/gradle.properties`.

### Workflow `gradlew-validate.yaml`:
- `ubuntu-22.04` → `ubuntu-24.04`

Closes #234