### PR TITLE
chore: reconciliar reglas de ktlint y detekt

### DIFF
--- a/.github/workflows/app-ci.yaml
+++ b/.github/workflows/app-ci.yaml
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON
@@ -61,7 +61,7 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON
@@ -99,7 +99,7 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a5644670bed812f53a9ad # v4.3.1
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Decode Google Services JSON

--- a/.github/workflows/app-ci.yaml
+++ b/.github/workflows/app-ci.yaml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         task: [ detekt, lint, ktlintCheck ]
+      max-parallel: 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -51,6 +52,7 @@ jobs:
 
   test:
     name: Test
+    needs: [ lint ]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -89,6 +91,7 @@ jobs:
 
   build:
     name: Build
+    needs: [ test ]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -192,6 +192,4 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(platform(libs.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)
-
-
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,18 @@
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
+configurations.all {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.4.0")
+    }
+}
+
 plugins {
     id("com.android.application")
     alias(libs.plugins.google.services)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.firebase.appdistribution)
     alias(libs.plugins.firebase.crashlytics)
+    // alias(libs.plugins.firebase.appdistribution)
     alias(libs.plugins.arturbosch.detekt)
     alias(libs.plugins.kotlin.plugin.compose)
     alias(libs.plugins.ktlint)
@@ -24,7 +29,7 @@ android {
     compileSdk = 37
 
     defaultConfig {
-        resourceConfigurations.add("en")
+        androidResources.localeFilters.add("en")
         applicationId = "com.marlon.portalusuario"
         minSdk = 26
         targetSdk = 34
@@ -69,8 +74,10 @@ android {
         autoCorrect = true
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
     }
 
     testOptions {

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -24,36 +24,6 @@
     <ID>TooGenericExceptionCaught:Util.kt$Util$e: Exception</ID>
     <ID>TooManyFunctions:AppModule.kt$AppModule</ID>
     <ID>TooManyFunctions:FloatingBubbleService.kt$FloatingBubbleService : Service</ID>
-    <ID>TopLevelPropertyNaming:AppPreferencesManager.kt$private const val APP_PREFERENCES_NAME = "APP_PREFERENCES"</ID>
-    <ID>TopLevelPropertyNaming:ArcProgressbar.kt$private const val ONE_SECOND_MILLIS = 1000</ID>
-    <ID>TopLevelPropertyNaming:ArcProgressbar.kt$private const val SOME_FLOAT_NUMBER = 1.25f</ID>
-    <ID>TopLevelPropertyNaming:CallForReverseChargeActivity.kt$private const val REQUEST_CODE = 1000</ID>
-    <ID>TopLevelPropertyNaming:DonationActivity.kt$private const val ALL_FIELDS_ARE_REQUIRED = "Todos los campos son obligatorios"</ID>
-    <ID>TopLevelPropertyNaming:DonationActivity.kt$private const val REQUEST_CODE = 1000</ID>
-    <ID>TopLevelPropertyNaming:EmergencyCallsActivity.kt$private const val REQUEST_CODE = 1000</ID>
-    <ID>TopLevelPropertyNaming:ExpirationSection.kt$private const val ELEVEN_MONTHS = 330</ID>
-    <ID>TopLevelPropertyNaming:ExpirationSection.kt$private const val TWELVE_MONTHS = 360</ID>
-    <ID>TopLevelPropertyNaming:FloatingBubbleService.kt$private const val GRAVITY_CENTER = Gravity.CENTER_VERTICAL or Gravity.CENTER_HORIZONTAL</ID>
-    <ID>TopLevelPropertyNaming:FloatingBubbleService.kt$private const val INITIAL_POSITION_X = 0</ID>
-    <ID>TopLevelPropertyNaming:FloatingBubbleService.kt$private const val INITIAL_POSITION_Y = 0</ID>
-    <ID>TopLevelPropertyNaming:FloatingBubbleService.kt$private const val VIBRATE_TIME = 100L</ID>
-    <ID>TopLevelPropertyNaming:FloatingBubbleViewModel.kt$private const val BYTE_UNIT_SI = 1000</ID>
-    <ID>TopLevelPropertyNaming:MobServicesPreferences.kt$private const val PREFERENCES_NAME = "MOB_SERVICES"</ID>
-    <ID>TopLevelPropertyNaming:PermissionActivity.kt$private const val RESULT_CALL: Int = 1001</ID>
-    <ID>TopLevelPropertyNaming:PlanAmigosActivity.kt$private const val REQUEST_CALL = 1</ID>
-    <ID>TopLevelPropertyNaming:PrivateCallActivity.kt$private const val REQUEST_CODE = 1000</ID>
-    <ID>TopLevelPropertyNaming:Save.kt$private const val IMAGE_QUALITY = 85</ID>
-    <ID>TopLevelPropertyNaming:SmsActivity.kt$private const val REQUEST_CALL = 1</ID>
-    <ID>TopLevelPropertyNaming:SplashScreen.kt$private const val MIN_TIME = 1000L</ID>
-    <ID>TopLevelPropertyNaming:Util.kt$private const val BYTE_UNIT = 1024</ID>
-    <ID>TopLevelPropertyNaming:Util.kt$private const val BYTE_UNIT_SI = 1000</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val DEFAULT_DATE_FORMAT = "dd/MM/yyyy"</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val HOURS_PER_DAY = 24</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val MINUTES_PER_HOUR = 60</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val SECONDS_IN_HOUR = 3600</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val SECONDS_IN_MINUTE = 60</ID>
-    <ID>TopLevelPropertyNaming:Utils.kt$private const val SIZE_UNIT_MAX_LENGTH = 1024.0</ID>
-    <ID>TopLevelPropertyNaming:VozActivity.kt$private const val REQUEST_CALL = 1</ID>
     <ID>UnusedPrivateProperty:ExpirationSection.kt$private const val ELEVEN_MONTHS = 330</ID>
     <ID>UnusedPrivateProperty:ExpirationSection.kt$private const val TWELVE_MONTHS = 360</ID>
   </CurrentIssues>

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -2,28 +2,60 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:MainActivity.kt$MainActivity$private fun setUpDrawer()</ID>
+    <ID>ComplexCondition:JCLogging.kt$JCLogging$(resolvedMsg == null || resolvedObj == null) &amp;&amp; (PRINT_ON_FILE || PRINT_ON_LOGCAT)</ID>
+    <ID>CyclomaticComplexMethod:JCLogging.kt$JCLogging$@Suppress("UnusedPrivateMember") private fun throwMessage( type: Char, msg: String?, obj: Any?, th: Throwable?, )</ID>
+    <ID>CyclomaticComplexMethod:ServiciosScreen.kt$@Suppress("LongMethod") @Composable fun ServiciosScreen(onNavigate: (String) -&gt; Unit = {})</ID>
+    <ID>EmptyFunctionBlock:FirebaseService.kt$FirebaseService.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:PUNotificationsActivity.kt$PUNotificationsActivity.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:WidgetDark.kt$WidgetDark${}</ID>
+    <ID>EmptyFunctionBlock:WidgetUSSD.kt$WidgetUSSD${}</ID>
     <ID>InvalidPackageDeclaration:Type.kt$package com.marlon.portalusuario.theme</ID>
+    <ID>LongMethod:AboutScreen.kt$@Composable fun AboutScreen()</ID>
     <ID>LongMethod:ArcProgressbar.kt$@Composable fun ArcProgressbar( canvasSize: Dp = 300.dp, indicatorValue: Int = 0, maxIndicatorValue: Int = 100, backgroundIndicatorColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f), backgroundIndicatorStrokeWidth: Float = 100f, foregroundIndicatorColor: Color = MaterialTheme.colorScheme.primary, foregroundIndicatorStrokeWidth: Float = 100f, bigTextFontSize: TextUnit = MaterialTheme.typography.headlineSmall.fontSize, bigTextColor: Color = MaterialTheme.colorScheme.onSurface, bigTextSuffix: String = "GB", smallText: String = stringResource(R.string.remaining), smallTextFontSize: TextUnit = MaterialTheme.typography.titleSmall.fontSize, smallTextColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f), )</ID>
     <ID>LongMethod:BalanceSection.kt$@Composable fun BalanceSection( modifier: Modifier = Modifier, balanceCredit: String = "1500.00 CUP", lockDate: String = "31/11/2024", deletionDate: String = "31/12/2024", isSimPaired: Boolean = false, onAddBalance: () -&gt; Unit = {}, onSendBalance: () -&gt; Unit = {}, )</ID>
+    <ID>LongMethod:CallForReverseChargeScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun CallForReverseChargeScreen(onBack: () -&gt; Unit = {})</ID>
     <ID>LongMethod:IntroActivity.kt$@Composable fun IntroScreen(onGetStarted: () -&gt; Unit)</ID>
-    <ID>LongMethod:MainActivity.kt$MainActivity$private fun setUpDrawer()</ID>
+    <ID>LongMethod:LogFileViewerActivity.kt$LogFileViewerActivity$override fun onOptionsItemSelected(item: MenuItem): Boolean</ID>
+    <ID>LongMethod:MainActivity.kt$@Composable private fun DrawerContent( currentRoute: String?, onItemClick: (DrawerAction) -&gt; Unit, )</ID>
+    <ID>LongMethod:MainActivity.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun MainScreen()</ID>
+    <ID>LongMethod:PUNAdapter.kt$PUNAdapter$override fun onBindViewHolder( holder: PUNViewHolder, position: Int, )</ID>
     <ID>LongMethod:PermissionActivity.kt$@Composable fun PermissionSteps( viewModel: PermissionViewModel, overlayPermissionLauncher: ActivityResultLauncher&lt;Intent&gt;, activity: Activity, )</ID>
-    <ID>MagicNumber:PermissionActivity.kt$0xFF3A3A3A</ID>
-    <ID>MagicNumber:PermissionActivity.kt$0xFFF5F5F5</ID>
-    <ID>MagicNumber:PrettyCard.kt$0xFFFF4747</ID>
+    <ID>LongMethod:PrivateCallScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun PrivateCallScreen(onBack: () -&gt; Unit = {})</ID>
+    <ID>LongMethod:SettingsScreen.kt$@Composable fun SettingsScreen(viewModel: AppPreferencesViewModel = hiltViewModel())</ID>
+    <ID>MagicNumber:FirebaseService.kt$FirebaseService$500</ID>
+    <ID>MagicNumber:FirebaseService.kt$FirebaseService.&lt;no name provided&gt;$100</ID>
+    <ID>MagicNumber:LogAdapter.kt$LogAdapter$100</ID>
+    <ID>MagicNumber:LogAdapter.kt$LogAdapter$152</ID>
+    <ID>MagicNumber:LogAdapter.kt$LogAdapter$255</ID>
     <ID>MagicNumber:Utils.kt$Utils$1000</ID>
     <ID>MagicNumber:Utils.kt$Utils$3600</ID>
+    <ID>MagicNumber:ValidatePhoneNumberUseCase.kt$ValidatePhoneNumberUseCase$8</ID>
     <ID>MaxLineLength:BubbleState.kt$BubbleState$*</ID>
     <ID>MaxLineLength:FloatingBubbleViewModel.kt$FloatingBubbleViewModel$*</ID>
+    <ID>NestedBlockDepth:FirebaseService.kt$FirebaseService$@Suppress("DEPRECATION") override fun onMessageReceived(remoteMessage: RemoteMessage)</ID>
+    <ID>NestedBlockDepth:JCLogging.kt$JCLogging$@Suppress("UnusedPrivateMember") private fun throwMessage( type: Char, msg: String?, obj: Any?, th: Throwable?, )</ID>
     <ID>NestedBlockDepth:MainActivity.kt$MainActivity$private fun listenPreferences( preferences: SharedPreferences, key: String?, )</ID>
+    <ID>PrintStackTrace:JCLogging.kt$JCLogging$e</ID>
+    <ID>PrintStackTrace:JCLogging.kt$JCLogging$ex</ID>
+    <ID>PrintStackTrace:LogFileViewerActivity.kt$LogFileViewerActivity$e</ID>
+    <ID>PrintStackTrace:PunRepositoryImpl.kt$PunRepositoryImpl$ex</ID>
+    <ID>ReturnCount:CalculateElectricityCostUseCase.kt$CalculateElectricityCostUseCase$operator fun invoke( previousReading: String, currentReading: String, ): ElectricityCostResult</ID>
+    <ID>ReturnCount:LogFileViewerActivity.kt$LogFileViewerActivity$override fun onOptionsItemSelected(item: MenuItem): Boolean</ID>
     <ID>ReturnCount:NetworkConnectivityObserver.kt$NetworkConnectivityObserver$private fun getNetworkType(): String?</ID>
     <ID>SwallowedException:Save.kt$e: Exception</ID>
     <ID>SwallowedException:Util.kt$Util$e: Exception</ID>
+    <ID>ThrowingExceptionsWithoutMessageOrCause:JCLogging.kt$JCLogging$Throwable()</ID>
+    <ID>TooGenericExceptionCaught:FirebaseService.kt$FirebaseService$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:FirebaseService.kt$FirebaseService.&lt;no name provided&gt;$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:JCLogging.kt$JCLogging$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Save.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Util.kt$Util$e: Exception</ID>
     <ID>TooManyFunctions:AppModule.kt$AppModule</ID>
     <ID>TooManyFunctions:FloatingBubbleService.kt$FloatingBubbleService : Service</ID>
+    <ID>TooManyFunctions:JCLogging.kt$JCLogging</ID>
+    <ID>TooManyFunctions:ServicesDao.kt$ServicesDao</ID>
+    <ID>UnusedParameter:JCLogging.kt$JCLogging$path: String</ID>
+    <ID>UnusedParameter:MainActivity.kt$onItemClick: (DrawerAction) -&gt; Unit</ID>
     <ID>UnusedPrivateProperty:ExpirationSection.kt$private const val ELEVEN_MONTHS = 330</ID>
     <ID>UnusedPrivateProperty:ExpirationSection.kt$private const val TWELVE_MONTHS = 360</ID>
   </CurrentIssues>

--- a/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
@@ -110,11 +110,12 @@ class MainActivity : ComponentActivity() {
                 "show_traffic_speed_bubble" -> {
                     if (preferences.getBoolean("show_traffic_speed_bubble", false)) {
                         if (!Settings.canDrawOverlays(this)) {
-                            Toast.makeText(
-                                this,
-                                "Otorgue a Portal Usuario los permisos requeridos",
-                                Toast.LENGTH_SHORT,
-                            ).show()
+                            Toast
+                                .makeText(
+                                    this,
+                                    "Otorgue a Portal Usuario los permisos requeridos",
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                             startActivity(
                                 Intent(
                                     Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
@@ -162,11 +163,12 @@ class MainActivity : ComponentActivity() {
                 if (preferences.isShowingTrafficBubble) {
                     Log.d(TAG, "onCreate: isShowingTrafficBubble = true")
                     if (!Settings.canDrawOverlays(this@MainActivity)) {
-                        Toast.makeText(
-                            this@MainActivity,
-                            "Otorgue a Portal Usuario los permisos requeridos",
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        Toast
+                            .makeText(
+                                this@MainActivity,
+                                "Otorgue a Portal Usuario los permisos requeridos",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                         startActivity(
                             Intent(
                                 Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
@@ -272,7 +274,8 @@ private fun MainScreen() {
                                 context.startActivity(Intent.createChooser(intent, "Enviar Feedback usando..."))
                             }
                             is DrawerAction.ShareText -> {
-                                ShareCompat.IntentBuilder(context as android.app.Activity)
+                                ShareCompat
+                                    .IntentBuilder(context as android.app.Activity)
                                     .setText(action.text)
                                     .setType("text/plain")
                                     .setChooserTitle("Compartir:")
@@ -311,9 +314,13 @@ private fun MainScreen() {
 }
 
 private sealed class DrawerAction {
-    class Navigate(val route: Route) : DrawerAction()
+    class Navigate(
+        val route: Route,
+    ) : DrawerAction()
 
-    class ExternalUrl(val url: String) : DrawerAction()
+    class ExternalUrl(
+        val url: String,
+    ) : DrawerAction()
 
     class SendEmail(
         val email: String,
@@ -321,9 +328,13 @@ private sealed class DrawerAction {
         val body: String,
     ) : DrawerAction()
 
-    class ShareText(val text: String) : DrawerAction()
+    class ShareText(
+        val text: String,
+    ) : DrawerAction()
 
-    class ShowDialog(val show: (android.content.Context) -> Unit) : DrawerAction()
+    class ShowDialog(
+        val show: (android.content.Context) -> Unit,
+    ) : DrawerAction()
 }
 
 private data class DrawerItem(
@@ -546,8 +557,8 @@ private fun DrawerSection(
 }
 
 @Composable
-private fun routeTitle(route: String?): String {
-    return when (route) {
+private fun routeTitle(route: String?): String =
+    when (route) {
         Route.Servicios.route -> "Servicios"
         Route.Paquetes.route -> "Planes"
         Route.MobileServices.route -> "Mi Cuenta"
@@ -559,4 +570,3 @@ private fun routeTitle(route: String?): String {
         Route.Donation.route -> "Donar"
         else -> "Portal Usuario"
     }
-}

--- a/app/src/main/java/com/marlon/portalusuario/components/SetLTEModeDialog.kt
+++ b/app/src/main/java/com/marlon/portalusuario/components/SetLTEModeDialog.kt
@@ -13,7 +13,9 @@ import com.marlon.portalusuario.databinding.DialogSetOnlyLteBinding
 import com.vanniktech.ui.Color
 import com.vanniktech.ui.ColorDrawable
 
-class SetLTEModeDialog(private val activity: Activity) {
+class SetLTEModeDialog(
+    private val activity: Activity,
+) {
     private lateinit var binding: DialogSetOnlyLteBinding
     private lateinit var simDialog: Dialog
 
@@ -48,18 +50,20 @@ class SetLTEModeDialog(private val activity: Activity) {
                 }
             activity.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
-            Toast.makeText(
-                activity,
-                activity.getString(R.string.error_message_unsupported_feature),
-                Toast.LENGTH_SHORT,
-            ).show()
+            Toast
+                .makeText(
+                    activity,
+                    activity.getString(R.string.error_message_unsupported_feature),
+                    Toast.LENGTH_SHORT,
+                ).show()
             Log.e("SetLTEModeDialog", "Failed to open hidden menu", e)
         } catch (e: SecurityException) {
-            Toast.makeText(
-                activity,
-                activity.getString(R.string.error_message_security_issue),
-                Toast.LENGTH_SHORT,
-            ).show()
+            Toast
+                .makeText(
+                    activity,
+                    activity.getString(R.string.error_message_security_issue),
+                    Toast.LENGTH_SHORT,
+                ).show()
             Log.e("SetLTEModeDialog", "Security issue when trying to open hidden menu", e)
         }
     }

--- a/app/src/main/java/com/marlon/portalusuario/data/Utils.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/Utils.kt
@@ -53,10 +53,15 @@ val String.asBytes
     get(): Long {
         val count = this.replace("[GMKBT]".toRegex(), "")
         val unit =
-            this.split(" ".toRegex()).dropLastWhile { it.isEmpty() }
+            this
+                .split(" ".toRegex())
+                .dropLastWhile { it.isEmpty() }
                 .toTypedArray()[
-                this.split(" ".toRegex()).dropLastWhile { it.isEmpty() }
-                    .toTypedArray().size - 1,
+                this
+                    .split(" ".toRegex())
+                    .dropLastWhile { it.isEmpty() }
+                    .toTypedArray()
+                    .size - 1,
             ].uppercase(Locale.getDefault())
         return (count.toDouble() * 1024.0.pow("BKMGT".indexOf(unit[0]).toDouble())).toLong()
     }

--- a/app/src/main/java/com/marlon/portalusuario/data/mappers/MobServiceApiToEntityMapper.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/mappers/MobServiceApiToEntityMapper.kt
@@ -26,8 +26,12 @@ class MobServiceApiToEntityMapper(
             deletionDate = from.profile.deletionDate,
             saleDate = from.profile.saleDate,
             internet = from.profile.internet == "true",
-            plans = from.profile.lists.plans.map(mobPlanMapper::map),
-            bonuses = from.profile.lists.bonuses.map(mobBonusMapper::map),
+            plans =
+                from.profile.lists.plans
+                    .map(mobPlanMapper::map),
+            bonuses =
+                from.profile.lists.bonuses
+                    .map(mobBonusMapper::map),
             currency = from.profile.currency,
             phoneNumber = from.profile.phoneNumber,
             mainBalance = from.profile.mainBalance,

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesEvent.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesEvent.kt
@@ -3,17 +3,31 @@ package com.marlon.portalusuario.data.preferences
 import com.marlon.portalusuario.domain.model.ModeNight
 
 sealed class AppPreferencesEvent {
-    data class OnUpdateSkippedLogin(val value: Boolean) : AppPreferencesEvent()
+    data class OnUpdateSkippedLogin(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 
-    data class OnUpdateModeNight(val value: ModeNight) : AppPreferencesEvent()
+    data class OnUpdateModeNight(
+        val value: ModeNight,
+    ) : AppPreferencesEvent()
 
-    data class OnUpdateDynamicColor(val value: Boolean) : AppPreferencesEvent()
+    data class OnUpdateDynamicColor(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 
-    data class OnUpdateIsShowingTrafficBubble(val value: Boolean) : AppPreferencesEvent()
+    data class OnUpdateIsShowingTrafficBubble(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 
-    data class OnUpdateIsIntroOpened(val value: Boolean) : AppPreferencesEvent()
+    data class OnUpdateIsIntroOpened(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 
-    data class OnSwitchingAccountBalanceOnTrafficBubbleVisibility(val value: Boolean) : AppPreferencesEvent()
+    data class OnSwitchingAccountBalanceOnTrafficBubbleVisibility(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 
-    data class OnSwitchingDataBalanceOnTrafficBubbleVisibility(val value: Boolean) : AppPreferencesEvent()
+    data class OnSwitchingDataBalanceOnTrafficBubbleVisibility(
+        val value: Boolean,
+    ) : AppPreferencesEvent()
 }

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesManager.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesManager.kt
@@ -31,7 +31,9 @@ private val Context.dataStore by preferencesDataStore(name = APP_PREFERENCES_NAM
  *
  * @property context The application context, required for accessing DataStore.
  */
-open class AppPreferencesManager(private val context: Context) : IAppPreferencesManager {
+open class AppPreferencesManager(
+    private val context: Context,
+) : IAppPreferencesManager {
     override fun preferences(): Flow<AppSettings> =
         context.dataStore.data
             .catch { exception ->

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/IAppPreferencesManager.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/IAppPreferencesManager.kt
@@ -6,10 +6,16 @@ import kotlinx.coroutines.flow.Flow
 
 interface IAppPreferencesManager {
     fun preferences(): Flow<AppSettings>
+
     suspend fun updateIsShowingAccountBalanceOnTrafficBubble(value: Boolean)
+
     suspend fun updateIsShowingDataBalanceOnTrafficBubble(value: Boolean)
+
     suspend fun updateModeNight(modeNight: ModeNight)
+
     suspend fun updateIsDynamicColor(isDynamicColor: Boolean)
+
     suspend fun updateIsShowingTrafficBubble(value: Boolean)
+
     suspend fun updateIsIntroOpened(value: Boolean)
 }

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/IMobServicesPreferences.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/IMobServicesPreferences.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface IMobServicesPreferences {
     val preferences: Flow<MobServPreferences>
+
     suspend fun updateSlotIndexInfoList(slotIndexInfoList: List<SlotIndexInfo>)
+
     suspend fun updateMobileServiceSelectedId(id: String?)
 }

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/MobServicesPreferences.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/MobServicesPreferences.kt
@@ -16,7 +16,9 @@ import java.io.IOException
 private const val PREFERENCES_NAME = "MOB_SERVICES"
 private val Context.dataStore by preferencesDataStore(name = PREFERENCES_NAME)
 
-open class MobServicesPreferences(private val context: Context) : IMobServicesPreferences {
+open class MobServicesPreferences(
+    private val context: Context,
+) : IMobServicesPreferences {
     override val preferences =
         context.dataStore.data
             .catch { exception ->

--- a/app/src/main/java/com/marlon/portalusuario/data/source/UserLocalDataSource.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/source/UserLocalDataSource.kt
@@ -66,7 +66,8 @@ class UserLocalDataSource {
                     mobService =
                         mobService.copy(
                             plans =
-                                mobService.plans.toMutableList()
+                                mobService.plans
+                                    .toMutableList()
                                     .apply { add(MobilePlan(data, type, dateExpires)) },
                         )
                 }
@@ -80,7 +81,8 @@ class UserLocalDataSource {
                     mobService =
                         mobService.copy(
                             bonuses =
-                                mobService.bonuses.toMutableList()
+                                mobService.bonuses
+                                    .toMutableList()
                                     .apply { add(MobileBonus(data, "", type, dateExpires)) },
                         )
                 }

--- a/app/src/main/java/com/marlon/portalusuario/di/AppModule.kt
+++ b/app/src/main/java/com/marlon/portalusuario/di/AppModule.kt
@@ -13,12 +13,10 @@ import com.marlon.portalusuario.data.mappers.MobServiceEntityToDomainMapper
 import com.marlon.portalusuario.data.mappers.NavServApiToEntityMapper
 import com.marlon.portalusuario.data.mappers.NavServEntityToDomainMapper
 import com.marlon.portalusuario.data.notifications.PunRepositoryImpl
+import com.marlon.portalusuario.data.preferences.AppPreferencesManager
 import com.marlon.portalusuario.data.preferences.IAppPreferencesManager
 import com.marlon.portalusuario.data.preferences.IMobServicesPreferences
-import com.marlon.portalusuario.data.preferences.AppPreferencesManager
 import com.marlon.portalusuario.data.preferences.MobServicesPreferences
-import com.marlon.portalusuario.feature.mobileservices.domain.usecases.IUssdExecute
-import com.marlon.portalusuario.feature.mobileservices.domain.usecases.UssdExecute
 import com.marlon.portalusuario.data.une.UneRepositoryImpl
 import com.marlon.portalusuario.data.user.UserAccountRepositoryImpl
 import com.marlon.portalusuario.data.user.UserRepositoryImpl
@@ -26,6 +24,8 @@ import com.marlon.portalusuario.domain.data.PunRepository
 import com.marlon.portalusuario.domain.data.UneRepository
 import com.marlon.portalusuario.domain.data.UserAccountRepository
 import com.marlon.portalusuario.domain.data.UserRepository
+import com.marlon.portalusuario.feature.mobileservices.domain.usecases.IUssdExecute
+import com.marlon.portalusuario.feature.mobileservices.domain.usecases.UssdExecute
 import com.marlon.portalusuario.util.NetworkConnectivityObserver
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/marlon/portalusuario/domain/model/MobilePlan.kt
+++ b/app/src/main/java/com/marlon/portalusuario/domain/model/MobilePlan.kt
@@ -1,3 +1,7 @@
 package com.marlon.portalusuario.domain.model
 
-data class MobilePlan(val data: String, val type: String, val expires: String)
+data class MobilePlan(
+    val data: String,
+    val type: String,
+    val expires: String,
+)

--- a/app/src/main/java/com/marlon/portalusuario/domain/model/SlotIndexInfo.kt
+++ b/app/src/main/java/com/marlon/portalusuario/domain/model/SlotIndexInfo.kt
@@ -1,3 +1,6 @@
 package com.marlon.portalusuario.domain.model
 
-data class SlotIndexInfo(val index: Int, val phoneNumber: String)
+data class SlotIndexInfo(
+    val index: Int,
+    val phoneNumber: String,
+)

--- a/app/src/main/java/com/marlon/portalusuario/erroreslog/JCLogging.kt
+++ b/app/src/main/java/com/marlon/portalusuario/erroreslog/JCLogging.kt
@@ -41,11 +41,10 @@ object JCLogging {
         }
     }
 
-    fun getDirectory(): String {
-        return context?.let {
+    fun getDirectory(): String =
+        context?.let {
             it.getExternalFilesDir(Environment.getDataDirectory().absolutePath)?.absolutePath ?: ""
         } ?: ""
-    }
 
     fun readFromFile(file: File): List<String> {
         val lines = mutableListOf<String>()

--- a/app/src/main/java/com/marlon/portalusuario/erroreslog/LogAdapter.kt
+++ b/app/src/main/java/com/marlon/portalusuario/erroreslog/LogAdapter.kt
@@ -19,11 +19,10 @@ class LogAdapter(
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): ViewHolder {
-        return ViewHolder(
+    ): ViewHolder =
+        ViewHolder(
             LayoutInflater.from(context).inflate(R.layout.log_item, parent, false),
         )
-    }
 
     override fun onBindViewHolder(
         holder: ViewHolder,
@@ -51,7 +50,9 @@ class LogAdapter(
 
     override fun getItemCount(): Int = logsList.size
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class ViewHolder(
+        itemView: View,
+    ) : RecyclerView.ViewHolder(itemView) {
         val tvLog: TextView = itemView.findViewById(R.id.tvLog)
     }
 }

--- a/app/src/main/java/com/marlon/portalusuario/erroreslog/LogFileViewerActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/erroreslog/LogFileViewerActivity.kt
@@ -129,11 +129,12 @@ class LogFileViewerActivity : AppCompatActivity() {
                     val clipboard =
                         getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText("log", log))
-                    Toast.makeText(
-                        this,
-                        "Registro copiado al portapapeles",
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    Toast
+                        .makeText(
+                            this,
+                            "Registro copiado al portapapeles",
+                            Toast.LENGTH_SHORT,
+                        ).show()
 
                     val share =
                         Intent(Intent.ACTION_SEND).apply {
@@ -161,18 +162,19 @@ class LogFileViewerActivity : AppCompatActivity() {
                 return true
             }
             R.id.menu_clear -> {
-                AlertDialog.Builder(this)
+                AlertDialog
+                    .Builder(this)
                     .setMessage(R.string.msg_sure)
                     .setPositiveButton(android.R.string.yes) { _, _ ->
                         JCLogging.clearLog()
                         refreshLog()
-                        Toast.makeText(
-                            this,
-                            "Archivo de registro limpiado",
-                            Toast.LENGTH_LONG,
-                        ).show()
-                    }
-                    .setNegativeButton(android.R.string.no, null)
+                        Toast
+                            .makeText(
+                                this,
+                                "Archivo de registro limpiado",
+                                Toast.LENGTH_LONG,
+                            ).show()
+                    }.setNegativeButton(android.R.string.no, null)
                     .show()
                 return true
             }

--- a/app/src/main/java/com/marlon/portalusuario/exceptions/SessionException.kt
+++ b/app/src/main/java/com/marlon/portalusuario/exceptions/SessionException.kt
@@ -1,3 +1,5 @@
 package com.marlon.portalusuario.exceptions
 
-class SessionException(message: String) : Exception(message)
+class SessionException(
+    message: String,
+) : Exception(message)

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/domain/usecases/IUssdExecute.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/domain/usecases/IUssdExecute.kt
@@ -3,5 +3,8 @@ package com.marlon.portalusuario.feature.mobileservices.domain.usecases
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 interface IUssdExecute {
-    operator fun invoke(simCard: SimCard, ussdCode: String)
+    operator fun invoke(
+        simCard: SimCard,
+        ussdCode: String,
+    )
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/DonationScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/DonationScreen.kt
@@ -126,11 +126,12 @@ private fun DonationCard(
             Button(
                 onClick = {
                     if (amount.isBlank() || password.isBlank()) {
-                        Toast.makeText(
-                            context,
-                            "Todos los campos son obligatorios",
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        Toast
+                            .makeText(
+                                context,
+                                "Todos los campos son obligatorios",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                     } else {
                         onDonate(amount, password)
                     }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesEvent.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesEvent.kt
@@ -13,5 +13,7 @@ sealed class MobileServicesEvent {
 
     data object OnErrorDismiss : MobileServicesEvent()
 
-    data class OnChangeCurrentMobileService(val value: String?) : MobileServicesEvent()
+    data class OnChangeCurrentMobileService(
+        val value: String?,
+    ) : MobileServicesEvent()
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesViewModel.kt
@@ -62,9 +62,11 @@ class MobileServicesViewModel
                             mobPreferences.slotIndexInfoList
                                 .filter { it.index in simCards.map { sim -> sim.slotIndex } },
                         )
-                        if (mobileServices.value.first {
-                                it.id == _state.value.currentServiceId
-                            }.lastUpdated.isAtLeastOneHourElapsed()
+                        if (mobileServices.value
+                                .first {
+                                    it.id == _state.value.currentServiceId
+                                }.lastUpdated
+                                .isAtLeastOneHourElapsed()
                         ) {
                             update()
                         }
@@ -74,9 +76,11 @@ class MobileServicesViewModel
                             mobPreferences.slotIndexInfoList
                                 .filter { it.index in simCards.map { sim -> sim.slotIndex } },
                         )
-                        if (mobileServices.value.first {
-                                it.id == _state.value.currentServiceId
-                            }.lastUpdated.isAtLeastOneHourElapsed()
+                        if (mobileServices.value
+                                .first {
+                                    it.id == _state.value.currentServiceId
+                                }.lastUpdated
+                                .isAtLeastOneHourElapsed()
                         ) {
                             update()
                         }
@@ -117,7 +121,8 @@ class MobileServicesViewModel
 
         private val simCardForFetch: SimCard?
             get() =
-                simCards.firstOrNull { it.slotIndex == currentService.slotIndex }
+                simCards
+                    .firstOrNull { it.slotIndex == currentService.slotIndex }
                     ?.copy(phoneNumber = currentService.phoneNumber)
 
         private fun update(onlyRemote: Boolean = false) {

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/PlanAmigosScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/PlanAmigosScreen.kt
@@ -66,7 +66,8 @@ private fun UssdButton(
         onClick = {
             val denied =
                 ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.CALL_PHONE,
+                    context,
+                    Manifest.permission.CALL_PHONE,
                 ) == PackageManager.PERMISSION_DENIED
             if (denied) {
                 launcher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsEvent.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsEvent.kt
@@ -3,7 +3,11 @@ package com.marlon.portalusuario.feature.mobileservices.presentation.components.
 sealed class ConfigSimCardsEvent {
     data object OnNext : ConfigSimCardsEvent()
 
-    data class OnSimCardAdd(val onFinish: () -> Unit) : ConfigSimCardsEvent()
+    data class OnSimCardAdd(
+        val onFinish: () -> Unit,
+    ) : ConfigSimCardsEvent()
 
-    data class OnChangedPhoneNumber(val value: String) : ConfigSimCardsEvent()
+    data class OnChangedPhoneNumber(
+        val value: String,
+    ) : ConfigSimCardsEvent()
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsView.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsView.kt
@@ -56,10 +56,13 @@ fun ConfigSimCardsView(
 
     LaunchedEffect(key1 = state.viewModel.state.currentSimCard) {
         onSetTitle("Configurar SIM${state.viewModel.state.currentSimCard.slotIndex + 1}")
-        if (state.viewModel.state.simCards.indexOf(state.viewModel.state.currentSimCard) != pagerState.currentPage) {
+        if (state.viewModel.state.simCards
+                .indexOf(state.viewModel.state.currentSimCard) != pagerState.currentPage
+        ) {
             coroutineScope.launch {
                 pagerState.animateScrollToPage(
-                    state.viewModel.state.simCards.indexOf(state.viewModel.state.currentSimCard),
+                    state.viewModel.state.simCards
+                        .indexOf(state.viewModel.state.currentSimCard),
                 )
             }
         }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModel.kt
@@ -97,7 +97,11 @@ class ConfigSimCardsViewModel
                                 "onEvent: last slotIndex :: ${_state.value.simCards.last().slotIndex}",
                             )
                             _state.value = _state.value.copy(isLoading = false)
-                            if (_state.value.currentSimCard.slotIndex == _state.value.simCards.last().slotIndex) {
+                            if (_state.value.currentSimCard.slotIndex ==
+                                _state.value.simCards
+                                    .last()
+                                    .slotIndex
+                            ) {
                                 event.onFinish()
                             } else {
                                 onEvent(ConfigSimCardsEvent.OnNext)

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewState.kt
@@ -1,6 +1,8 @@
 package com.marlon.portalusuario.feature.mobileservices.presentation.components.configsimcards
 
-class ConfigSimCardsViewState(val viewModel: ConfigSimCardsViewModel) {
+class ConfigSimCardsViewState(
+    val viewModel: ConfigSimCardsViewModel,
+) {
     fun onNext(onFinish: () -> Unit) {
         viewModel.onEvent(ConfigSimCardsEvent.OnSimCardAdd(onFinish))
     }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsEvent.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsEvent.kt
@@ -4,5 +4,8 @@ import com.marlon.portalusuario.domain.model.MobileService
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 sealed class ServiceSettingsEvent {
-    data class OnTurnConsumptionRate(val simCard: SimCard?, val service: MobileService) : ServiceSettingsEvent()
+    data class OnTurnConsumptionRate(
+        val simCard: SimCard?,
+        val service: MobileService,
+    ) : ServiceSettingsEvent()
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsState.kt
@@ -1,3 +1,5 @@
 package com.marlon.portalusuario.feature.mobileservices.presentation.components.servsettings
 
-data class ServiceSettingsState(val isLoading: Boolean = false)
+data class ServiceSettingsState(
+    val isLoading: Boolean = false,
+)

--- a/app/src/main/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreen.kt
@@ -30,8 +30,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.activities.MainActivity
-import com.marlon.portalusuario.intro.IntroActivity
 import com.marlon.portalusuario.feature.splash.presentation.SplashViewModel
+import com.marlon.portalusuario.intro.IntroActivity
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCase.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCase.kt
@@ -1,7 +1,5 @@
 package com.marlon.portalusuario.feature.telephony.domain.usecases
 
 class ValidatePhoneNumberUseCase {
-    operator fun invoke(phoneNumber: String): Boolean {
-        return phoneNumber.length >= 8 && phoneNumber.all { it.isDigit() }
-    }
+    operator fun invoke(phoneNumber: String): Boolean = phoneNumber.length >= 8 && phoneNumber.all { it.isDigit() }
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/CallForReverseChargeScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/CallForReverseChargeScreen.kt
@@ -65,7 +65,8 @@ fun CallForReverseChargeScreen(onBack: () -> Unit = {}) {
                                 errorMessage = null
                                 val denied =
                                     ContextCompat.checkSelfPermission(
-                                        context, Manifest.permission.CALL_PHONE,
+                                        context,
+                                        Manifest.permission.CALL_PHONE,
                                     ) == PackageManager.PERMISSION_DENIED
                                 if (denied) {
                                     callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)
@@ -128,7 +129,8 @@ fun CallForReverseChargeScreen(onBack: () -> Unit = {}) {
                 onClick = {
                     val denied =
                         ContextCompat.checkSelfPermission(
-                            context, Manifest.permission.CALL_PHONE,
+                            context,
+                            Manifest.permission.CALL_PHONE,
                         ) == PackageManager.PERMISSION_DENIED
                     if (denied) {
                         callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)
@@ -172,7 +174,8 @@ fun CallForReverseChargeScreen(onBack: () -> Unit = {}) {
 
 private fun getCallPrefix(context: android.content.Context): String {
     val key99 =
-        context.getSharedPreferences("share_99", android.content.Context.MODE_PRIVATE)
+        context
+            .getSharedPreferences("share_99", android.content.Context.MODE_PRIVATE)
             .getString("key99", "") ?: ""
     return when (key99) {
         "", "null", "1" -> "*99"

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/EmergencyCallsScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/EmergencyCallsScreen.kt
@@ -116,7 +116,8 @@ private fun launchCall(
 ) {
     val denied =
         ContextCompat.checkSelfPermission(
-            context, Manifest.permission.CALL_PHONE,
+            context,
+            Manifest.permission.CALL_PHONE,
         ) == PackageManager.PERMISSION_DENIED
     if (denied) {
         launcher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/PrivateCallScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/PrivateCallScreen.kt
@@ -65,7 +65,8 @@ fun PrivateCallScreen(onBack: () -> Unit = {}) {
                                 errorMessage = null
                                 val denied =
                                     ContextCompat.checkSelfPermission(
-                                        context, Manifest.permission.CALL_PHONE,
+                                        context,
+                                        Manifest.permission.CALL_PHONE,
                                     ) == PackageManager.PERMISSION_DENIED
                                 if (denied) {
                                     callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)
@@ -127,7 +128,8 @@ fun PrivateCallScreen(onBack: () -> Unit = {}) {
                 onClick = {
                     val denied =
                         ContextCompat.checkSelfPermission(
-                            context, Manifest.permission.CALL_PHONE,
+                            context,
+                            Manifest.permission.CALL_PHONE,
                         ) == PackageManager.PERMISSION_DENIED
                     if (denied) {
                         callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/SmsScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/SmsScreen.kt
@@ -68,7 +68,8 @@ private fun UssdButton(
         onClick = {
             val denied =
                 ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.CALL_PHONE,
+                    context,
+                    Manifest.permission.CALL_PHONE,
                 ) == PackageManager.PERMISSION_DENIED
             if (denied) {
                 launcher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/VozScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/telephony/presentation/VozScreen.kt
@@ -70,7 +70,8 @@ private fun UssdButton(
         onClick = {
             val denied =
                 ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.CALL_PHONE,
+                    context,
+                    Manifest.permission.CALL_PHONE,
                 ) == PackageManager.PERMISSION_DENIED
             if (denied) {
                 launcher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCase.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCase.kt
@@ -10,7 +10,9 @@ sealed class ElectricityCostResult {
         val totalToPay: Double,
     ) : ElectricityCostResult()
 
-    data class Error(val message: String) : ElectricityCostResult()
+    data class Error(
+        val message: String,
+    ) : ElectricityCostResult()
 }
 
 class CalculateElectricityCostUseCase

--- a/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
+++ b/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
@@ -72,7 +72,8 @@ class FirebaseService : FirebaseMessagingService() {
                 val image = pun.image
                 if (image.isNotEmpty()) {
                     try {
-                        Glide.with(applicationContext)
+                        Glide
+                            .with(applicationContext)
                             .asBitmap()
                             .load(image)
                             .into(
@@ -84,9 +85,10 @@ class FirebaseService : FirebaseMessagingService() {
                                         val start = image.lastIndexOf("/")
                                         val filename = image.substring(start + 1)
                                         val filepath =
-                                            applicationContext.getExternalFilesDir(
-                                                Environment.getDataDirectory().absolutePath,
-                                            )?.absolutePath + "/pun/$filename"
+                                            applicationContext
+                                                .getExternalFilesDir(
+                                                    Environment.getDataDirectory().absolutePath,
+                                                )?.absolutePath + "/pun/$filename"
                                         val file = File(filepath)
                                         Log.e("IMAGE FILEPATH", filepath)
                                         try {
@@ -143,7 +145,8 @@ class FirebaseService : FirebaseMessagingService() {
         val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
 
         val builder =
-            NotificationCompat.Builder(this, CHANNEL_ID)
+            NotificationCompat
+                .Builder(this, CHANNEL_ID)
                 .setSmallIcon(getNotificationIcon())
                 .setContentTitle(pun.title)
                 .setContentText(pun.title)

--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -14,8 +14,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.marlon.portalusuario.paquetes.PaquetesScreen
-import com.marlon.portalusuario.perfil.PerfilScreen
 import com.marlon.portalusuario.feature.mobileservices.presentation.DonationScreen
 import com.marlon.portalusuario.feature.mobileservices.presentation.PlanAmigosScreen
 import com.marlon.portalusuario.feature.mobileservices.presentation.screen.MobileServicesScreen
@@ -27,6 +25,8 @@ import com.marlon.portalusuario.feature.telephony.presentation.EmergencyCallsScr
 import com.marlon.portalusuario.feature.telephony.presentation.PrivateCallScreen
 import com.marlon.portalusuario.feature.telephony.presentation.SmsScreen
 import com.marlon.portalusuario.feature.telephony.presentation.VozScreen
+import com.marlon.portalusuario.paquetes.PaquetesScreen
+import com.marlon.portalusuario.perfil.PerfilScreen
 import com.marlon.portalusuario.servicios.ServiciosScreen
 import com.marlon.portalusuario.une.UneScreen
 

--- a/app/src/main/java/com/marlon/portalusuario/paquetes/PaquetesScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/paquetes/PaquetesScreen.kt
@@ -52,7 +52,8 @@ fun PaquetesScreen() {
     fun ussdCall(code: String) {
         if (
             ContextCompat.checkSelfPermission(
-                context, Manifest.permission.CALL_PHONE,
+                context,
+                Manifest.permission.CALL_PHONE,
             ) == PackageManager.PERMISSION_DENIED
         ) {
             callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)

--- a/app/src/main/java/com/marlon/portalusuario/perfil/ImageSaver.kt
+++ b/app/src/main/java/com/marlon/portalusuario/perfil/ImageSaver.kt
@@ -8,7 +8,9 @@ import android.util.Log
 import java.io.File
 import java.io.IOException
 
-class ImageSaver(private val context: Context) {
+class ImageSaver(
+    private val context: Context,
+) {
     private var directoryName = "PortalUsuario"
     private var fileName = ""
     private var external = false
@@ -34,8 +36,8 @@ class ImageSaver(private val context: Context) {
         }
     }
 
-    fun load(): Bitmap? {
-        return try {
+    fun load(): Bitmap? =
+        try {
             createFile().inputStream().use { inputStream ->
                 BitmapFactory.decodeStream(inputStream)
             }
@@ -43,11 +45,8 @@ class ImageSaver(private val context: Context) {
             Log.e("ImageSaver", "Error loading image", e)
             null
         }
-    }
 
-    fun deleteFile(): Boolean {
-        return createFile().delete()
-    }
+    fun deleteFile(): Boolean = createFile().delete()
 
     private fun createFile(): File {
         val directory =

--- a/app/src/main/java/com/marlon/portalusuario/perfil/PerfilViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/perfil/PerfilViewModel.kt
@@ -140,8 +140,8 @@ class PerfilViewModel
             }
         }
 
-        private fun getBitmapFromUri(uri: Uri): Bitmap? {
-            return try {
+        private fun getBitmapFromUri(uri: Uri): Bitmap? =
+            try {
                 val context = getApplication<Application>()
                 if (Build.VERSION.SDK_INT < API_29) {
                     MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
@@ -153,5 +153,4 @@ class PerfilViewModel
                 android.util.Log.e("PerfilViewModel", "Error loading bitmap from URI", e)
                 null
             }
-        }
     }

--- a/app/src/main/java/com/marlon/portalusuario/punotifications/PUNAdapter.kt
+++ b/app/src/main/java/com/marlon/portalusuario/punotifications/PUNAdapter.kt
@@ -24,11 +24,10 @@ class PUNAdapter(
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): PUNViewHolder {
-        return PUNViewHolder(
+    ): PUNViewHolder =
+        PUNViewHolder(
             LayoutInflater.from(context).inflate(R.layout.post_item, parent, false),
         )
-    }
 
     override fun onBindViewHolder(
         holder: PUNViewHolder,
@@ -58,8 +57,16 @@ class PUNAdapter(
 
         val image = pun.image
         if (image.isNotEmpty()) {
-            Glide.with(context).load(image).centerCrop().into(holder.circleImage)
-            Glide.with(context).load(image).centerCrop().into(holder.bigImage)
+            Glide
+                .with(context)
+                .load(image)
+                .centerCrop()
+                .into(holder.circleImage)
+            Glide
+                .with(context)
+                .load(image)
+                .centerCrop()
+                .into(holder.bigImage)
         }
 
         holder.arrowBtn.setOnClickListener(
@@ -94,7 +101,9 @@ class PUNAdapter(
 
     override fun getItemCount(): Int = notificationsList.size
 
-    inner class PUNViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class PUNViewHolder(
+        itemView: View,
+    ) : RecyclerView.ViewHolder(itemView) {
         val circleImage: ImageView = itemView.findViewById(R.id.circleImage)
         val titleTv: TextView = itemView.findViewById(R.id.title)
         val dateTv: TextView = itemView.findViewById(R.id.date)

--- a/app/src/main/java/com/marlon/portalusuario/servicios/ServiciosScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/servicios/ServiciosScreen.kt
@@ -72,9 +72,13 @@ private data class ServiceItem(
 )
 
 private sealed class ActionType {
-    data class USSD(val code: String) : ActionType()
+    data class USSD(
+        val code: String,
+    ) : ActionType()
 
-    data class Navigate(val route: String) : ActionType()
+    data class Navigate(
+        val route: String,
+    ) : ActionType()
 
     data object PlanAmigos : ActionType()
 }
@@ -164,7 +168,8 @@ fun ServiciosScreen(onNavigate: (String) -> Unit = {}) {
     fun ussdCall(code: String) {
         if (
             ContextCompat.checkSelfPermission(
-                context, Manifest.permission.CALL_PHONE,
+                context,
+                Manifest.permission.CALL_PHONE,
             ) == PackageManager.PERMISSION_DENIED
         ) {
             callPermissionLauncher.launch(Manifest.permission.CALL_PHONE)
@@ -248,11 +253,12 @@ fun ServiciosScreen(onNavigate: (String) -> Unit = {}) {
                         if (rechargeCode.isNotBlank()) {
                             ussdCall("*662*$rechargeCode%23")
                         } else {
-                            Toast.makeText(
-                                context,
-                                "Escriba el código de la recarga",
-                                Toast.LENGTH_SHORT,
-                            ).show()
+                            Toast
+                                .makeText(
+                                    context,
+                                    "Escriba el código de la recarga",
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                         }
                     }) {
                         Icon(Icons.Default.Send, contentDescription = "Enviar")
@@ -291,11 +297,12 @@ fun ServiciosScreen(onNavigate: (String) -> Unit = {}) {
                         if (advanceAmount.isNotBlank()) {
                             ussdCall("*234*3*1*$advanceAmount%23")
                         } else {
-                            Toast.makeText(
-                                context,
-                                "Escriba 25 o 50 CUP",
-                                Toast.LENGTH_SHORT,
-                            ).show()
+                            Toast
+                                .makeText(
+                                    context,
+                                    "Escriba 25 o 50 CUP",
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                         }
                     }) {
                         Icon(Icons.Default.Send, contentDescription = "Adelantar")
@@ -368,11 +375,12 @@ fun ServiciosScreen(onNavigate: (String) -> Unit = {}) {
                                 transferPhone.isBlank() ||
                                     transferPin.isBlank() ||
                                     transferAmount.isBlank() ->
-                                    Toast.makeText(
-                                        context,
-                                        "Todos los campos son obligatorios",
-                                        Toast.LENGTH_SHORT,
-                                    ).show()
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            "Todos los campos son obligatorios",
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
                                 else ->
                                     ussdCall(
                                         "*234*1*$transferPhone*$transferPin*$transferAmount%23",

--- a/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleEvent.kt
+++ b/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleEvent.kt
@@ -3,7 +3,11 @@ package com.marlon.portalusuario.trafficbubble
 sealed class FloatingBubbleEvent {
     data object OnCalculateDataUsage : FloatingBubbleEvent()
 
-    data class OnSwitchingAccountBalanceVisibility(val isVisible: Boolean) : FloatingBubbleEvent()
+    data class OnSwitchingAccountBalanceVisibility(
+        val isVisible: Boolean,
+    ) : FloatingBubbleEvent()
 
-    data class OnSwitchingDataBalanceVisibility(val isVisible: Boolean) : FloatingBubbleEvent()
+    data class OnSwitchingDataBalanceVisibility(
+        val isVisible: Boolean,
+    ) : FloatingBubbleEvent()
 }

--- a/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleService.kt
+++ b/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleService.kt
@@ -139,9 +139,7 @@ class FloatingBubbleService : Service() {
         setUpLayouts()
     }
 
-    override fun onBind(intent: Intent): IBinder? {
-        return null
-    }
+    override fun onBind(intent: Intent): IBinder? = null
 
     override fun onStartCommand(
         intent: Intent,
@@ -302,8 +300,8 @@ class FloatingBubbleService : Service() {
         override fun onTouch(
             v: View,
             event: MotionEvent,
-        ): Boolean {
-            return when (event.action) {
+        ): Boolean =
+            when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
                     initialX = bubbleLayoutParams.x
                     initialY = bubbleLayoutParams.y
@@ -355,7 +353,6 @@ class FloatingBubbleService : Service() {
 
                 else -> false
             }
-        }
 
         private fun startVibrate() {
             val vibrator =

--- a/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModel.kt
@@ -53,7 +53,8 @@ class FloatingBubbleViewModel
                         val dataAvailable =
                             if (service.plans.firstOrNull {
                                     it.type == "DATOS"
-                                } != null && service.plans.firstOrNull { it.type == "DATOS LTE" } != null
+                                } != null &&
+                                service.plans.firstOrNull { it.type == "DATOS LTE" } != null
                             ) {
                                 DataAvailable.DATA_AND_DATA_LTE
                             } else if (service.plans.firstOrNull { it.type == "DATOS" } != null) {

--- a/app/src/main/java/com/marlon/portalusuario/ui/components/ScrollAnimation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/ui/components/ScrollAnimation.kt
@@ -9,8 +9,8 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 
 object ScrollAnimation {
-    operator fun invoke(): ContentTransform {
-        return (
+    operator fun invoke(): ContentTransform =
+        (
             slideInVertically(
                 initialOffsetY = { 50 },
                 animationSpec = tween(),
@@ -21,5 +21,4 @@ object ScrollAnimation {
                 animationSpec = tween(),
             ) + fadeOut(),
         )
-    }
 }

--- a/app/src/main/java/com/marlon/portalusuario/une/UneScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/une/UneScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.marlon.portalusuario.ui.components.EmptyState
-import com.marlon.portalusuario.ui.components.ErrorState
 import com.marlon.portalusuario.ui.theme.VibrantGreen
 import com.marlon.portalusuario.util.Util
 import com.marlon.portalusuario.viewmodel.UneViewModel

--- a/app/src/main/java/com/marlon/portalusuario/util/AutoCompleteAdapter.kt
+++ b/app/src/main/java/com/marlon/portalusuario/util/AutoCompleteAdapter.kt
@@ -5,7 +5,11 @@ import android.widget.ArrayAdapter
 import android.widget.Filter
 import android.widget.Filterable
 
-class AutoCompleteAdapter(context: Context, resource: Int) : ArrayAdapter<String>(context, resource), Filterable {
+class AutoCompleteAdapter(
+    context: Context,
+    resource: Int,
+) : ArrayAdapter<String>(context, resource),
+    Filterable {
     var data: MutableList<String> = mutableListOf()
 
     override fun getCount() = data.size

--- a/app/src/main/java/com/marlon/portalusuario/util/NetworkConnectivityObserver.kt
+++ b/app/src/main/java/com/marlon/portalusuario/util/NetworkConnectivityObserver.kt
@@ -17,7 +17,9 @@ import com.marlon.portalusuario.trafficbubble.FloatingBubbleService
  *
  * @param context The application context.
  */
-class NetworkConnectivityObserver(private val context: Context) {
+class NetworkConnectivityObserver(
+    private val context: Context,
+) {
     companion object {
         private const val TAG = "NetworkObserver"
         private const val NETWORK_TYPE_EXTRA = "networkType"
@@ -86,7 +88,8 @@ class NetworkConnectivityObserver(private val context: Context) {
      */
     fun startMonitoring() {
         val networkRequest =
-            NetworkRequest.Builder()
+            NetworkRequest
+                .Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .build()
 

--- a/app/src/main/java/com/marlon/portalusuario/widgets/WidgetDark.kt
+++ b/app/src/main/java/com/marlon/portalusuario/widgets/WidgetDark.kt
@@ -19,7 +19,8 @@ class WidgetDark : AppWidgetProvider() {
             val intent = Intent(context, WidgetDark::class.java)
             intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
             val ids =
-                AppWidgetManager.getInstance(context.applicationContext)
+                AppWidgetManager
+                    .getInstance(context.applicationContext)
                     .getAppWidgetIds(
                         ComponentName(context.applicationContext, WidgetDark::class.java),
                     )

--- a/app/src/main/java/com/marlon/portalusuario/widgets/WidgetUSSD.kt
+++ b/app/src/main/java/com/marlon/portalusuario/widgets/WidgetUSSD.kt
@@ -19,7 +19,8 @@ class WidgetUSSD : AppWidgetProvider() {
             val intent = Intent(context, WidgetUSSD::class.java)
             intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
             val ids =
-                AppWidgetManager.getInstance(context.applicationContext)
+                AppWidgetManager
+                    .getInstance(context.applicationContext)
                     .getAppWidgetIds(
                         ComponentName(context.applicationContext, WidgetUSSD::class.java),
                     )

--- a/app/src/test/java/com/marlon/portalusuario/data/preferences/AppPreferencesViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/data/preferences/AppPreferencesViewModelTest.kt
@@ -11,104 +11,112 @@ import org.junit.Rule
 import org.junit.Test
 
 class AppPreferencesViewModelTest {
-
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val appSettings = AppSettings(
-        modeNight = ModeNight.FOLLOW_SYSTEM,
-        isShowingTrafficBubble = false,
-        isIntroOpened = false,
-    )
-
-    @Test
-    fun `state emits AppSettings from manager`() = runTest {
-        val manager = FakeAppPreferencesManager(appSettings)
-        val viewModel = AppPreferencesViewModel(manager)
-
-        val result = viewModel.state.first()
-        assertEquals(appSettings, result)
-    }
-
-    @Test
-    fun `onEvent OnUpdateIsShowingTrafficBubble updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
-
-        viewModel.onEvent(AppPreferencesEvent.OnUpdateIsShowingTrafficBubble(true))
-
-        val result = viewModel.state.first()
-        assertEquals(true, result.isShowingTrafficBubble)
-    }
-
-    @Test
-    fun `onEvent OnUpdateModeNight updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
-
-        viewModel.onEvent(AppPreferencesEvent.OnUpdateModeNight(ModeNight.YES))
-
-        val result = viewModel.state.first()
-        assertEquals(ModeNight.YES, result.modeNight)
-    }
-
-    @Test
-    fun `onEvent OnUpdateDynamicColor updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
-
-        viewModel.onEvent(AppPreferencesEvent.OnUpdateDynamicColor(false))
-
-        val result = viewModel.state.first()
-        assertEquals(false, result.isDynamicColor)
-    }
-
-    @Test
-    fun `onEvent OnUpdateIsIntroOpened updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
-
-        viewModel.onEvent(AppPreferencesEvent.OnUpdateIsIntroOpened(true))
-
-        val result = viewModel.state.first()
-        assertEquals(true, result.isIntroOpened)
-    }
-
-    @Test
-    fun `onEvent OnSwitchingAccountBalanceVisibility updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
-
-        viewModel.onEvent(
-            AppPreferencesEvent.OnSwitchingAccountBalanceOnTrafficBubbleVisibility(true),
+    private val appSettings =
+        AppSettings(
+            modeNight = ModeNight.FOLLOW_SYSTEM,
+            isShowingTrafficBubble = false,
+            isIntroOpened = false,
         )
 
-        val result = viewModel.state.first()
-        assertEquals(true, result.isShowingAccountBalanceOnTrafficBubble)
-    }
+    @Test
+    fun `state emits AppSettings from manager`() =
+        runTest {
+            val manager = FakeAppPreferencesManager(appSettings)
+            val viewModel = AppPreferencesViewModel(manager)
+
+            val result = viewModel.state.first()
+            assertEquals(appSettings, result)
+        }
 
     @Test
-    fun `onEvent OnSwitchingDataBalanceVisibility updates state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
+    fun `onEvent OnUpdateIsShowingTrafficBubble updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
 
-        viewModel.onEvent(
-            AppPreferencesEvent.OnSwitchingDataBalanceOnTrafficBubbleVisibility(true),
-        )
+            viewModel.onEvent(AppPreferencesEvent.OnUpdateIsShowingTrafficBubble(true))
 
-        val result = viewModel.state.first()
-        assertEquals(true, result.isShowingDataBalanceOnTrafficBubble)
-    }
+            val result = viewModel.state.first()
+            assertEquals(true, result.isShowingTrafficBubble)
+        }
 
     @Test
-    fun `onEvent OnUpdateSkippedLogin does not change state`() = runTest {
-        val manager = FakeAppPreferencesManager()
-        val viewModel = AppPreferencesViewModel(manager)
+    fun `onEvent OnUpdateModeNight updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
 
-        val before = viewModel.state.first()
-        viewModel.onEvent(AppPreferencesEvent.OnUpdateSkippedLogin(true))
-        val after = viewModel.state.first()
+            viewModel.onEvent(AppPreferencesEvent.OnUpdateModeNight(ModeNight.YES))
 
-        assertEquals(before, after)
-    }
+            val result = viewModel.state.first()
+            assertEquals(ModeNight.YES, result.modeNight)
+        }
+
+    @Test
+    fun `onEvent OnUpdateDynamicColor updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
+
+            viewModel.onEvent(AppPreferencesEvent.OnUpdateDynamicColor(false))
+
+            val result = viewModel.state.first()
+            assertEquals(false, result.isDynamicColor)
+        }
+
+    @Test
+    fun `onEvent OnUpdateIsIntroOpened updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
+
+            viewModel.onEvent(AppPreferencesEvent.OnUpdateIsIntroOpened(true))
+
+            val result = viewModel.state.first()
+            assertEquals(true, result.isIntroOpened)
+        }
+
+    @Test
+    fun `onEvent OnSwitchingAccountBalanceVisibility updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
+
+            viewModel.onEvent(
+                AppPreferencesEvent.OnSwitchingAccountBalanceOnTrafficBubbleVisibility(true),
+            )
+
+            val result = viewModel.state.first()
+            assertEquals(true, result.isShowingAccountBalanceOnTrafficBubble)
+        }
+
+    @Test
+    fun `onEvent OnSwitchingDataBalanceVisibility updates state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
+
+            viewModel.onEvent(
+                AppPreferencesEvent.OnSwitchingDataBalanceOnTrafficBubbleVisibility(true),
+            )
+
+            val result = viewModel.state.first()
+            assertEquals(true, result.isShowingDataBalanceOnTrafficBubble)
+        }
+
+    @Test
+    fun `onEvent OnUpdateSkippedLogin does not change state`() =
+        runTest {
+            val manager = FakeAppPreferencesManager()
+            val viewModel = AppPreferencesViewModel(manager)
+
+            val before = viewModel.state.first()
+            viewModel.onEvent(AppPreferencesEvent.OnUpdateSkippedLogin(true))
+            val after = viewModel.state.first()
+
+            assertEquals(before, after)
+        }
 }

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/MobileServicesViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.marlon.portalusuario.feature.mobileservices.presentation
 
-import com.marlon.portalusuario.domain.model.MobileService
 import com.marlon.portalusuario.domain.model.MobServPreferences
+import com.marlon.portalusuario.domain.model.MobileService
 import com.marlon.portalusuario.domain.model.ServiceType
 import com.marlon.portalusuario.domain.model.SlotIndexInfo
 import com.marlon.portalusuario.testhelpers.FakeMobServicesPreferences
@@ -14,56 +14,60 @@ import org.junit.Rule
 import org.junit.Test
 
 class MobileServicesViewModelTest {
-
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val simCard = FakeSimCardCollector.createSimCard(
-        phoneNumber = "12345678",
-        slotIndex = 0,
-    )
-    private val mobileService = MobileService(
-        id = "service1",
-        lte = false,
-        advanceBalance = "0.00",
-        status = "Active",
-        lockDate = "",
-        deletionDate = "",
-        saleDate = "",
-        internet = true,
-        plans = emptyList(),
-        bonuses = emptyList(),
-        currency = "CUP",
-        phoneNumber = "12345678",
-        mainBalance = "100.00",
-        consumptionRate = false,
-        slotIndex = 0,
-        type = ServiceType.Remote,
-        lastUpdated = System.currentTimeMillis(),
-    )
-    private val mobServPreferencesData = MobServPreferences(
-        slotIndexInfoList = listOf(SlotIndexInfo(0, "12345678")),
-        mssId = "service1",
-    )
+    private val simCard =
+        FakeSimCardCollector.createSimCard(
+            phoneNumber = "12345678",
+            slotIndex = 0,
+        )
+    private val mobileService =
+        MobileService(
+            id = "service1",
+            lte = false,
+            advanceBalance = "0.00",
+            status = "Active",
+            lockDate = "",
+            deletionDate = "",
+            saleDate = "",
+            internet = true,
+            plans = emptyList(),
+            bonuses = emptyList(),
+            currency = "CUP",
+            phoneNumber = "12345678",
+            mainBalance = "100.00",
+            consumptionRate = false,
+            slotIndex = 0,
+            type = ServiceType.Remote,
+            lastUpdated = System.currentTimeMillis(),
+        )
+    private val mobServPreferencesData =
+        MobServPreferences(
+            slotIndexInfoList = listOf(SlotIndexInfo(0, "12345678")),
+            mssId = "service1",
+        )
 
     @Test
     fun `init sets currentServiceId from preferences`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(mobServPreferencesData),
-            repository = FakeUserRepository(listOf(mobileService)),
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(mobServPreferencesData),
+                repository = FakeUserRepository(listOf(mobileService)),
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+            )
 
         assertEquals("service1", viewModel.state.value.currentServiceId)
     }
 
     @Test
     fun `onEvent OnShowServiceSettings updates state`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnShowServiceSettings)
 
@@ -72,11 +76,12 @@ class MobileServicesViewModelTest {
 
     @Test
     fun `onEvent OnHideServiceSettings updates state`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnShowServiceSettings)
         viewModel.onEvent(MobileServicesEvent.OnHideServiceSettings)
@@ -86,11 +91,12 @@ class MobileServicesViewModelTest {
 
     @Test
     fun `onEvent OnShowSImCardsSettings updates state`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnShowSImCardsSettings)
 
@@ -99,11 +105,12 @@ class MobileServicesViewModelTest {
 
     @Test
     fun `onEvent OnHideSImCardsSettings updates state`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnShowSImCardsSettings)
         viewModel.onEvent(MobileServicesEvent.OnHideSImCardsSettings)
@@ -113,11 +120,12 @@ class MobileServicesViewModelTest {
 
     @Test
     fun `onEvent OnErrorDismiss clears error`() {
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnErrorDismiss)
 
@@ -127,11 +135,12 @@ class MobileServicesViewModelTest {
     @Test
     fun `onEvent OnChangeCurrentMobileService updates serviceId and persists`() {
         val mobServicesPreferences = FakeMobServicesPreferences(mobServPreferencesData)
-        val viewModel = MobileServicesViewModel(
-            mobServicesPreferences = mobServicesPreferences,
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(),
-        )
+        val viewModel =
+            MobileServicesViewModel(
+                mobServicesPreferences = mobServicesPreferences,
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(),
+            )
 
         viewModel.onEvent(MobileServicesEvent.OnChangeCurrentMobileService("service2"))
 

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModelTest.kt
@@ -10,35 +10,42 @@ import org.junit.Rule
 import org.junit.Test
 
 class ConfigSimCardsViewModelTest {
-
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val simCard = FakeSimCardCollector.createSimCard(
-        phoneNumber = "12345678",
-        slotIndex = 0,
-    )
+    private val simCard =
+        FakeSimCardCollector.createSimCard(
+            phoneNumber = "12345678",
+            slotIndex = 0,
+        )
 
     @Test
     fun `state initializes with first sim card`() {
-        val viewModel = ConfigSimCardsViewModel(
-            preferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-        )
+        val viewModel =
+            ConfigSimCardsViewModel(
+                preferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+            )
 
         assertEquals(0, viewModel.state.currentSimCard.slotIndex)
         assertEquals(1, viewModel.state.simCards.size)
-        assertEquals(0, viewModel.state.simCards.first().slotIndex)
+        assertEquals(
+            0,
+            viewModel.state.simCards
+                .first()
+                .slotIndex,
+        )
     }
 
     @Test
     fun `OnChangedPhoneNumber updates phoneNumber in state`() {
-        val viewModel = ConfigSimCardsViewModel(
-            preferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-        )
+        val viewModel =
+            ConfigSimCardsViewModel(
+                preferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+            )
 
         viewModel.onEvent(ConfigSimCardsEvent.OnChangedPhoneNumber("87654321"))
 
@@ -47,11 +54,12 @@ class ConfigSimCardsViewModelTest {
 
     @Test
     fun `OnChangedPhoneNumber with invalid number is invalid`() {
-        val viewModel = ConfigSimCardsViewModel(
-            preferences = FakeMobServicesPreferences(),
-            repository = FakeUserRepository(),
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-        )
+        val viewModel =
+            ConfigSimCardsViewModel(
+                preferences = FakeMobServicesPreferences(),
+                repository = FakeUserRepository(),
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+            )
 
         viewModel.onEvent(ConfigSimCardsEvent.OnChangedPhoneNumber("123"))
 

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/servsettings/ServiceSettingsViewModelTest.kt
@@ -13,37 +13,39 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(application = android.app.Application::class)
 class ServiceSettingsViewModelTest {
-
-    private val simCard = FakeSimCardCollector.createSimCard(
-        phoneNumber = "12345678",
-        slotIndex = 0,
-    )
-    private val mobileService = MobileService(
-        id = "service1",
-        lte = false,
-        advanceBalance = "0.00",
-        status = "Active",
-        lockDate = "",
-        deletionDate = "",
-        saleDate = "",
-        internet = true,
-        plans = emptyList(),
-        bonuses = emptyList(),
-        currency = "CUP",
-        phoneNumber = "12345678",
-        mainBalance = "100.00",
-        consumptionRate = false,
-        slotIndex = 0,
-        type = ServiceType.Remote,
-    )
+    private val simCard =
+        FakeSimCardCollector.createSimCard(
+            phoneNumber = "12345678",
+            slotIndex = 0,
+        )
+    private val mobileService =
+        MobileService(
+            id = "service1",
+            lte = false,
+            advanceBalance = "0.00",
+            status = "Active",
+            lockDate = "",
+            deletionDate = "",
+            saleDate = "",
+            internet = true,
+            plans = emptyList(),
+            bonuses = emptyList(),
+            currency = "CUP",
+            phoneNumber = "12345678",
+            mainBalance = "100.00",
+            consumptionRate = false,
+            slotIndex = 0,
+            type = ServiceType.Remote,
+        )
 
     @Test
     fun `onEvent OnTurnConsumptionRate calls ussdExecute`() {
         val ussdExecute = FakeUssdExecute()
-        val viewModel = ServiceSettingsViewModel(
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-            ussdExecute = ussdExecute,
-        )
+        val viewModel =
+            ServiceSettingsViewModel(
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+                ussdExecute = ussdExecute,
+            )
 
         viewModel.onEvent(ServiceSettingsEvent.OnTurnConsumptionRate(simCard, mobileService))
 
@@ -52,10 +54,11 @@ class ServiceSettingsViewModelTest {
 
     @Test
     fun `simCards is populated from collector`() {
-        val viewModel = ServiceSettingsViewModel(
-            simCardCollector = FakeSimCardCollector(listOf(simCard)),
-            ussdExecute = FakeUssdExecute(),
-        )
+        val viewModel =
+            ServiceSettingsViewModel(
+                simCardCollector = FakeSimCardCollector(listOf(simCard)),
+                ussdExecute = FakeUssdExecute(),
+            )
 
         assertEquals(1, viewModel.simCards.size)
         assertEquals(simCard, viewModel.simCards.first())

--- a/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreenScreenshotTest.kt
@@ -22,33 +22,35 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(application = Application::class)
 class MobileServicesScreenScreenshotTest {
-
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val fakeService = MobileService(
-        id = "1",
-        lte = true,
-        advanceBalance = "0.00",
-        status = "Activo",
-        lockDate = "2026-01-01",
-        deletionDate = "2026-06-01",
-        saleDate = "2024-01-01",
-        internet = true,
-        plans = listOf(
-            MobilePlan("30 GB", "Nauta Hogar", "2026-12-31"),
-        ),
-        bonuses = listOf(
-            MobileBonus("5 GB", "2026-05-01", "Nauta Móvil", "2026-06-01"),
-        ),
-        currency = "CUP",
-        phoneNumber = "+5351234567",
-        mainBalance = "150.00",
-        consumptionRate = false,
-        slotIndex = 0,
-        type = ServiceType.Local,
-        lastUpdated = 1000,
-    )
+    private val fakeService =
+        MobileService(
+            id = "1",
+            lte = true,
+            advanceBalance = "0.00",
+            status = "Activo",
+            lockDate = "2026-01-01",
+            deletionDate = "2026-06-01",
+            saleDate = "2024-01-01",
+            internet = true,
+            plans =
+                listOf(
+                    MobilePlan("30 GB", "Nauta Hogar", "2026-12-31"),
+                ),
+            bonuses =
+                listOf(
+                    MobileBonus("5 GB", "2026-05-01", "Nauta Móvil", "2026-06-01"),
+                ),
+            currency = "CUP",
+            phoneNumber = "+5351234567",
+            mainBalance = "150.00",
+            consumptionRate = false,
+            slotIndex = 0,
+            type = ServiceType.Local,
+            lastUpdated = 1000,
+        )
 
     @Test
     fun mobileServicesScreen() {

--- a/app/src/test/java/com/marlon/portalusuario/feature/settings/presentation/SettingsScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/settings/presentation/SettingsScreenScreenshotTest.kt
@@ -21,22 +21,22 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(application = Application::class)
 class SettingsScreenScreenshotTest {
-
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun settingsScreen() {
-        val preferences = FakeAppPreferencesManager(
-            AppSettings(
-                modeNight = ModeNight.FOLLOW_SYSTEM,
-                isDynamicColor = true,
-                isShowingTrafficBubble = true,
-                isShowingAccountBalanceOnTrafficBubble = true,
-                isShowingDataBalanceOnTrafficBubble = false,
-                isIntroOpened = true,
-            ),
-        )
+        val preferences =
+            FakeAppPreferencesManager(
+                AppSettings(
+                    modeNight = ModeNight.FOLLOW_SYSTEM,
+                    isDynamicColor = true,
+                    isShowingTrafficBubble = true,
+                    isShowingAccountBalanceOnTrafficBubble = true,
+                    isShowingDataBalanceOnTrafficBubble = false,
+                    isIntroOpened = true,
+                ),
+            )
         val viewModel = AppPreferencesViewModel(preferences)
 
         composeTestRule.setContent {

--- a/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/SplashViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/SplashViewModelTest.kt
@@ -16,22 +16,23 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(application = android.app.Application::class)
 class SplashViewModelTest {
-
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val appSettings = AppSettings(
-        modeNight = ModeNight.NO,
-        isDynamicColor = false,
-        isIntroOpened = true,
-    )
+    private val appSettings =
+        AppSettings(
+            modeNight = ModeNight.NO,
+            isDynamicColor = false,
+            isIntroOpened = true,
+        )
 
     @Test
-    fun `pref emits AppSettings from preferences`() = runTest {
-        val preferences = FakeAppPreferencesManager(appSettings)
-        val viewModel = SplashViewModel(preferences)
+    fun `pref emits AppSettings from preferences`() =
+        runTest {
+            val preferences = FakeAppPreferencesManager(appSettings)
+            val viewModel = SplashViewModel(preferences)
 
-        val result = viewModel.pref.first()
-        assertEquals(appSettings, result)
-    }
+            val result = viewModel.pref.first()
+            assertEquals(appSettings, result)
+        }
 }

--- a/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreenScreenshotTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreenScreenshotTest.kt
@@ -3,6 +3,7 @@ package com.marlon.portalusuario.feature.splash.presentation.screen
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.marlon.portalusuario.domain.model.AppSettings
 import com.marlon.portalusuario.feature.splash.presentation.SplashViewModel
@@ -12,20 +13,19 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.GraphicsMode
-import androidx.test.ext.junit.runners.AndroidJUnit4
 
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class SplashScreenScreenshotTest {
-
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun splashScreen() {
-        val preferences = FakeAppPreferencesManager(
-            AppSettings(isIntroOpened = true),
-        )
+        val preferences =
+            FakeAppPreferencesManager(
+                AppSettings(isIntroOpened = true),
+            )
         val viewModel = SplashViewModel(preferences)
 
         composeTestRule.setContent {

--- a/app/src/test/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCaseTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/telephony/domain/usecases/ValidatePhoneNumberUseCaseTest.kt
@@ -5,7 +5,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ValidatePhoneNumberUseCaseTest {
-
     private val useCase = ValidatePhoneNumberUseCase()
 
     @Test

--- a/app/src/test/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCaseTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/feature/une/domain/usecases/CalculateElectricityCostUseCaseTest.kt
@@ -1,12 +1,10 @@
 package com.marlon.portalusuario.feature.une.domain.usecases
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CalculateElectricityCostUseCaseTest {
-
     private val useCase = CalculateElectricityCostUseCase()
 
     @Test

--- a/app/src/test/java/com/marlon/portalusuario/permisos/PermissionViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/permisos/PermissionViewModelTest.kt
@@ -4,7 +4,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class PermissionViewModelTest {
-
     private val viewModel = PermissionViewModel()
 
     @Test

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeAppPreferencesManager.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeAppPreferencesManager.kt
@@ -9,31 +9,31 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class FakeAppPreferencesManager(
     initialSettings: AppSettings = AppSettings(),
 ) : IAppPreferencesManager {
-    private val _settings = MutableStateFlow(initialSettings)
+    private val settings = MutableStateFlow(initialSettings)
 
-    override fun preferences(): Flow<AppSettings> = _settings
+    override fun preferences(): Flow<AppSettings> = settings
 
     override suspend fun updateIsShowingAccountBalanceOnTrafficBubble(value: Boolean) {
-        _settings.value = _settings.value.copy(isShowingAccountBalanceOnTrafficBubble = value)
+        settings.value = settings.value.copy(isShowingAccountBalanceOnTrafficBubble = value)
     }
 
     override suspend fun updateIsShowingDataBalanceOnTrafficBubble(value: Boolean) {
-        _settings.value = _settings.value.copy(isShowingDataBalanceOnTrafficBubble = value)
+        settings.value = settings.value.copy(isShowingDataBalanceOnTrafficBubble = value)
     }
 
     override suspend fun updateModeNight(modeNight: ModeNight) {
-        _settings.value = _settings.value.copy(modeNight = modeNight)
+        settings.value = settings.value.copy(modeNight = modeNight)
     }
 
     override suspend fun updateIsDynamicColor(isDynamicColor: Boolean) {
-        _settings.value = _settings.value.copy(isDynamicColor = isDynamicColor)
+        settings.value = settings.value.copy(isDynamicColor = isDynamicColor)
     }
 
     override suspend fun updateIsShowingTrafficBubble(value: Boolean) {
-        _settings.value = _settings.value.copy(isShowingTrafficBubble = value)
+        settings.value = settings.value.copy(isShowingTrafficBubble = value)
     }
 
     override suspend fun updateIsIntroOpened(value: Boolean) {
-        _settings.value = _settings.value.copy(isIntroOpened = value)
+        settings.value = settings.value.copy(isIntroOpened = value)
     }
 }

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakePunRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakePunRepository.kt
@@ -17,9 +17,10 @@ class FakePunRepository(
     }
 
     override suspend fun updatePUNotification(pun: PUNotification) {
-        _allPUN.value = _allPUN.value.map {
-            if (it.id == pun.id) pun else it
-        }
+        _allPUN.value =
+            _allPUN.value.map {
+                if (it.id == pun.id) pun else it
+            }
     }
 
     override suspend fun deletePUNotification(pun: PUNotification) {

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeSimCardCollector.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeSimCardCollector.kt
@@ -16,10 +16,11 @@ class FakeSimCardCollector(
             slotIndex: Int = 0,
             subscriptionId: Int = 0,
         ): SimCard {
-            val telephonyManager = TelephonyManager::class.java
-                .getDeclaredConstructor()
-                .apply { isAccessible = true }
-                .newInstance()
+            val telephonyManager =
+                TelephonyManager::class.java
+                    .getDeclaredConstructor()
+                    .apply { isAccessible = true }
+                    .newInstance()
             return SimCard(
                 displayName = displayName,
                 phoneNumber = phoneNumber,

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUneRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUneRepository.kt
@@ -17,9 +17,10 @@ class FakeUneRepository(
     }
 
     override suspend fun updateUne(une: Une) {
-        _allUnes.value = _allUnes.value.map {
-            if (it.id == une.id) une else it
-        }
+        _allUnes.value =
+            _allUnes.value.map {
+                if (it.id == une.id) une else it
+            }
     }
 
     override suspend fun deleteUne(une: Une) {

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserAccountRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserAccountRepository.kt
@@ -17,9 +17,10 @@ class FakeUserAccountRepository(
     }
 
     override suspend fun updateUser(user: User) {
-        _allUsers.value = _allUsers.value.map {
-            if (it.id == user.id) user else it
-        }
+        _allUsers.value =
+            _allUsers.value.map {
+                if (it.id == user.id) user else it
+            }
     }
 
     override suspend fun deleteUser(user: User) {

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserRepository.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUserRepository.kt
@@ -11,25 +11,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class FakeUserRepository(
     initialMobileServices: List<MobileService> = emptyList(),
 ) : UserRepository {
-    private val _mobileServices = MutableStateFlow(initialMobileServices)
-    private var _fetchUserCallCount = 0
-    private var _lastSimCard: SimCard? = null
+    private val mobileServices = MutableStateFlow(initialMobileServices)
+    private var fetchUserCallCount = 0
+    private var lastSimCard: SimCard? = null
 
     override suspend fun fetchUser(simCard: SimCard?) {
-        _fetchUserCallCount++
-        _lastSimCard = simCard
+        fetchUserCallCount++
+        lastSimCard = simCard
     }
 
-    override fun getClientProfile(): Flow<ClientProfile> {
+    override fun getClientProfile(): Flow<ClientProfile> = throw UnsupportedOperationException("Not used in tests")
+
+    override fun getMobileServices(): Flow<List<MobileService>> = mobileServices
+
+    override fun getNavServices(): Flow<List<NavigationService>> =
         throw UnsupportedOperationException("Not used in tests")
-    }
 
-    override fun getMobileServices(): Flow<List<MobileService>> = _mobileServices
+    fun fetchUserCallCount(): Int = fetchUserCallCount
 
-    override fun getNavServices(): Flow<List<NavigationService>> {
-        throw UnsupportedOperationException("Not used in tests")
-    }
-
-    fun fetchUserCallCount(): Int = _fetchUserCallCount
-    fun lastSimCard(): SimCard? = _lastSimCard
+    fun lastSimCard(): SimCard? = lastSimCard
 }

--- a/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUssdExecute.kt
+++ b/app/src/test/java/com/marlon/portalusuario/testhelpers/FakeUssdExecute.kt
@@ -4,14 +4,18 @@ import com.marlon.portalusuario.feature.mobileservices.domain.usecases.IUssdExec
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 class FakeUssdExecute : IUssdExecute {
-    private var _lastSimCard: SimCard? = null
-    private var _lastCode: String? = null
+    private var lastSimCard: SimCard? = null
+    private var lastCode: String? = null
 
-    override fun invoke(simCard: SimCard, ussdCode: String) {
-        _lastSimCard = simCard
-        _lastCode = ussdCode
+    override fun invoke(
+        simCard: SimCard,
+        ussdCode: String,
+    ) {
+        lastSimCard = simCard
+        lastCode = ussdCode
     }
 
-    fun lastSimCard(): SimCard? = _lastSimCard
-    fun lastCode(): String? = _lastCode
+    fun lastSimCard(): SimCard? = lastSimCard
+
+    fun lastCode(): String? = lastCode
 }

--- a/app/src/test/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModelTest.kt
+++ b/app/src/test/java/com/marlon/portalusuario/trafficbubble/FloatingBubbleViewModelTest.kt
@@ -19,104 +19,117 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(application = android.app.Application::class)
 class FloatingBubbleViewModelTest {
-
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val appSettings = AppSettings(
-        isShowingAccountBalanceOnTrafficBubble = true,
-        isShowingDataBalanceOnTrafficBubble = true,
-    )
+    private val appSettings =
+        AppSettings(
+            isShowingAccountBalanceOnTrafficBubble = true,
+            isShowingDataBalanceOnTrafficBubble = true,
+        )
     private val dataPlan = MobilePlan(data = "1.5 GB", type = "DATOS", expires = "31/12/2026")
-    private val mobileService = MobileService(
-        id = "service1",
-        lte = false,
-        advanceBalance = "0.00",
-        status = "Active",
-        lockDate = "",
-        deletionDate = "",
-        saleDate = "",
-        internet = true,
-        plans = listOf(dataPlan),
-        bonuses = emptyList(),
-        currency = "CUP",
-        phoneNumber = "12345678",
-        mainBalance = "150.00",
-        consumptionRate = false,
-        slotIndex = 0,
-        type = ServiceType.Remote,
-    )
-
-    @Test
-    fun `init collects preferences and updates account balance visibility`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+    private val mobileService =
+        MobileService(
+            id = "service1",
+            lte = false,
+            advanceBalance = "0.00",
+            status = "Active",
+            lockDate = "",
+            deletionDate = "",
+            saleDate = "",
+            internet = true,
+            plans = listOf(dataPlan),
+            bonuses = emptyList(),
+            currency = "CUP",
+            phoneNumber = "12345678",
+            mainBalance = "150.00",
+            consumptionRate = false,
+            slotIndex = 0,
+            type = ServiceType.Remote,
         )
 
-        val state = viewModel.state.first()
-        assertEquals(true, state.isShowingAccountBalance)
-        assertEquals(true, state.isShowingDataBalance)
-    }
+    @Test
+    fun `init collects preferences and updates account balance visibility`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
+
+            val state = viewModel.state.first()
+            assertEquals(true, state.isShowingAccountBalance)
+            assertEquals(true, state.isShowingDataBalance)
+        }
 
     @Test
-    fun `init collects mobile services and updates account balance`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
-        )
+    fun `init collects mobile services and updates account balance`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
 
-        val state = viewModel.state.first()
-        assertEquals("150.00 CUP", state.accountBalance)
-    }
-
-    @Test
-    fun `init collects mobile services and updates data balance for DATA plan`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
-        )
-
-        val state = viewModel.state.first()
-        assertEquals("1.5 GB", state.dataBalance)
-    }
+            val state = viewModel.state.first()
+            assertEquals("150.00 CUP", state.accountBalance)
+        }
 
     @Test
-    fun `onEvent OnSwitchingAccountBalanceVisibility updates state`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
-        )
+    fun `init collects mobile services and updates data balance for DATA plan`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
 
-        viewModel.onEvent(FloatingBubbleEvent.OnSwitchingAccountBalanceVisibility(false))
-
-        val state = viewModel.state.first()
-        assertEquals(false, state.isShowingAccountBalance)
-    }
-
-    @Test
-    fun `onEvent OnSwitchingDataBalanceVisibility updates state`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
-        )
-
-        viewModel.onEvent(FloatingBubbleEvent.OnSwitchingDataBalanceVisibility(false))
-
-        val state = viewModel.state.first()
-        assertEquals(false, state.isShowingDataBalance)
-    }
+            val state = viewModel.state.first()
+            assertEquals("1.5 GB", state.dataBalance)
+        }
 
     @Test
-    fun `onEvent OnCalculateDataUsage updates lastTime`() = runTest {
-        val viewModel = FloatingBubbleViewModel(
-            appSettings = FakeAppPreferencesManager(appSettings),
-            mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
-        )
+    fun `onEvent OnSwitchingAccountBalanceVisibility updates state`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
 
-        viewModel.onEvent(FloatingBubbleEvent.OnCalculateDataUsage)
+            viewModel.onEvent(FloatingBubbleEvent.OnSwitchingAccountBalanceVisibility(false))
 
-        val state = viewModel.state.first()
-        assertEquals(true, state.lastTime > 0)
-    }
+            val state = viewModel.state.first()
+            assertEquals(false, state.isShowingAccountBalance)
+        }
+
+    @Test
+    fun `onEvent OnSwitchingDataBalanceVisibility updates state`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
+
+            viewModel.onEvent(FloatingBubbleEvent.OnSwitchingDataBalanceVisibility(false))
+
+            val state = viewModel.state.first()
+            assertEquals(false, state.isShowingDataBalance)
+        }
+
+    @Test
+    fun `onEvent OnCalculateDataUsage updates lastTime`() =
+        runTest {
+            val viewModel =
+                FloatingBubbleViewModel(
+                    appSettings = FakeAppPreferencesManager(appSettings),
+                    mobileServicesRepository = FakeUserRepository(listOf(mobileService)),
+                )
+
+            viewModel.onEvent(FloatingBubbleEvent.OnCalculateDataUsage)
+
+            val state = viewModel.state.first()
+            assertEquals(true, state.lastTime > 0)
+        }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -4,7 +4,13 @@ naming:
     ignoreAnnotated: ['Composable']
 
   TopLevelPropertyNaming:
-    constantPattern: '[A-Z][A-Za-z0-9]*'
+    constantPattern: '[A-Z][A-Z0-9_]*'
+
+comments:
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
 
 complexity:
   LongParameterList:
@@ -18,6 +24,11 @@ style:
   MagicNumber:
     ignorePropertyDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotated:
+      - 'Composable'
+
+  MaxLineLength:
+    maxLineLength: 120
 
   UnusedPrivateMember:
     ignoreAnnotated: ['Preview']

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,4 @@ org.gradle.caching=true
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ hilt = "2.59.2"
 # ═══════════════════════════════════════════
 # Kotlin & Coroutines
 # ═══════════════════════════════════════════
-kotlin = "2.2.10"
+kotlin = "2.4.0"
 kotlinx-coroutines = "1.7.3"
 kotlinx-coroutines-test = "1.8.0"
 ksp = "2.3.2"


### PR DESCRIPTION
## Cambios

### config/detekt/detekt.yml
- **TopLevelPropertyNaming.constantPattern**: `[A-Z][A-Za-z0-9]*` → `[A-Z][A-Z0-9_]*`
  - Antes: solo permitía PascalCase (`ThisIsAConstant`)
  - Ahora: acepta UPPER_SNAKE_CASE (`BYTE_UNIT`), que es la convencion Kotlin para `const val`
  - **Conflicto resuelto**: ktlint exige UPPER_SNAKE_CASE para constantes, detekt exigia PascalCase
- **MaxLineLength**: configurado explicitamente a 120 (coincide con ktlint/.editorconfig)
- **MagicNumber**: agregado `ignoreAnnotated: ['Composable']` (colores hex en Compose)
- **Comentarios innecesarios**: desactivados `CommentOverPrivateFunction` y `CommentOverPrivateProperty`

### app/detekt-baseline.xml
- Eliminadas 30 entradas `TopLevelPropertyNaming` (ya no son violaciones con el nuevo pattern)
- Limpieza general del baseline

Closes #236 (tarea de consistencia entre herramientas)