### PR TITLE
refactor: migrate PreferenceManager to DataStore (#280)

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
@@ -2,7 +2,6 @@ package com.marlon.portalusuario.activities
 
 import android.Manifest
 import android.content.Intent
-import android.content.SharedPreferences
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Build
@@ -73,7 +72,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.preference.PreferenceManager
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.components.SetLTEModeDialog
 import com.marlon.portalusuario.data.preferences.IAppPreferencesManager
@@ -99,39 +97,7 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var networkConnectivityObserver: NetworkConnectivityObserver
 
-    private lateinit var settings: SharedPreferences
     private var isDynamicColor by mutableStateOf(true)
-
-    private fun listenPreferences(
-        preferences: SharedPreferences,
-        key: String?,
-    ) {
-        key?.let {
-            when (it) {
-                "show_traffic_speed_bubble" -> {
-                    if (preferences.getBoolean("show_traffic_speed_bubble", false)) {
-                        if (!Settings.canDrawOverlays(this)) {
-                            Toast
-                                .makeText(
-                                    this,
-                                    "Otorgue a Portal Usuario los permisos requeridos",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
-                            startActivity(
-                                Intent(
-                                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                                    ("package:" + this.packageName).toUri(),
-                                ),
-                            )
-                        } else {
-                            val serviceIntent = Intent(this, FloatingBubbleService::class.java)
-                            stopService(serviceIntent)
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -184,14 +150,29 @@ class MainActivity : ComponentActivity() {
                     Log.d(TAG, "onCreate: isShowingTrafficBubble = false")
                     if (networkConnectivityObserver.isCallbackRegistered) networkConnectivityObserver.stopMonitoring()
                 }
+
+                if (preferences.isShowingTrafficSpeedBubble) {
+                    if (!Settings.canDrawOverlays(this@MainActivity)) {
+                        Toast
+                            .makeText(
+                                this@MainActivity,
+                                "Otorgue a Portal Usuario los permisos requeridos",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        startActivity(
+                            Intent(
+                                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                                ("package:" + this@MainActivity.packageName).toUri(),
+                            ),
+                        )
+                    } else {
+                        stopService(Intent(this@MainActivity, FloatingBubbleService::class.java))
+                    }
+                }
             }
         }
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
-
-        settings = PreferenceManager.getDefaultSharedPreferences(this)
-
-        settings.registerOnSharedPreferenceChangeListener(::listenPreferences)
 
         if (hasPermissions(
                 Manifest.permission.CALL_PHONE,
@@ -209,8 +190,6 @@ class MainActivity : ComponentActivity() {
             )
         }
 
-        PreferenceManager.setDefaultValues(this, R.xml.root_preferences, false)
-
         punViewModel = ViewModelProvider(this)[PunViewModel::class.java]
 
         setContent {
@@ -218,11 +197,6 @@ class MainActivity : ComponentActivity() {
                 MainScreen()
             }
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        settings.unregisterOnSharedPreferenceChangeListener(::listenPreferences)
     }
 
     companion object {

--- a/app/src/main/java/com/marlon/portalusuario/data/notifications/PunRepositoryImpl.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/notifications/PunRepositoryImpl.kt
@@ -2,10 +2,13 @@ package com.marlon.portalusuario.data.notifications
 
 import android.content.Context
 import android.widget.Toast
-import androidx.preference.PreferenceManager
 import com.marlon.portalusuario.data.ServicesDao
 import com.marlon.portalusuario.data.notifications.PunRepositoryImpl.Companion.NOTIFICATIONS_COUNT_KEY
+import com.marlon.portalusuario.data.preferences.notificationsCountFlow
+import com.marlon.portalusuario.data.preferences.setNotificationsCount
 import com.marlon.portalusuario.domain.data.PunRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import com.marlon.portalusuario.punotifications.PUNotification
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -22,10 +25,8 @@ class PunRepositoryImpl
         @Suppress("TooGenericExceptionCaught")
         override suspend fun insertPUNotification(pun: PUNotification) {
             dao.insertPUNotification(pun)
-            val sharedPreferences =
-                PreferenceManager.getDefaultSharedPreferences(appContext)
-            val count = sharedPreferences.getInt(NOTIFICATIONS_COUNT_KEY, 0)
-            sharedPreferences.edit().putInt(NOTIFICATIONS_COUNT_KEY, count + 1).apply()
+            val count = runBlocking { appContext.notificationsCountFlow().first() }
+            runBlocking { appContext.setNotificationsCount(count + 1) }
             try {
                 Toast
                     .makeText(

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/AppDataStore.kt
@@ -1,0 +1,46 @@
+package com.marlon.portalusuario.data.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.appDataStore by preferencesDataStore(name = "app_shared_preferences")
+
+object AppDataStoreKeys {
+    val SHOW_NOTIFICATIONS = booleanPreferencesKey("show_notifications")
+    val SAVE_LOGS = booleanPreferencesKey("save_logs")
+    val STORAGE_ADS = booleanPreferencesKey("storage_ads")
+    val NOTIFICATIONS_COUNT = intPreferencesKey("notifications_count")
+}
+
+fun Context.showNotificationsFlow(): Flow<Boolean> =
+    appDataStore.data.map { it[AppDataStoreKeys.SHOW_NOTIFICATIONS] ?: true }
+
+fun Context.saveLogsFlow(): Flow<Boolean> =
+    appDataStore.data.map { it[AppDataStoreKeys.SAVE_LOGS] ?: true }
+
+fun Context.storageAdsFlow(): Flow<Boolean> =
+    appDataStore.data.map { it[AppDataStoreKeys.STORAGE_ADS] ?: true }
+
+fun Context.notificationsCountFlow(): Flow<Int> =
+    appDataStore.data.map { it[AppDataStoreKeys.NOTIFICATIONS_COUNT] ?: 0 }
+
+suspend fun Context.setShowNotifications(enabled: Boolean) {
+    appDataStore.edit { it[AppDataStoreKeys.SHOW_NOTIFICATIONS] = enabled }
+}
+
+suspend fun Context.setSaveLogs(enabled: Boolean) {
+    appDataStore.edit { it[AppDataStoreKeys.SAVE_LOGS] = enabled }
+}
+
+suspend fun Context.setStorageAds(enabled: Boolean) {
+    appDataStore.edit { it[AppDataStoreKeys.STORAGE_ADS] = enabled }
+}
+
+suspend fun Context.setNotificationsCount(count: Int) {
+    appDataStore.edit { it[AppDataStoreKeys.NOTIFICATIONS_COUNT] = count }
+}

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesManager.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/AppPreferencesManager.kt
@@ -55,6 +55,8 @@ open class AppPreferencesManager(
                     preferences[AppPreferencesKeys.IS_SHOWING_ACCOUNT_BALANCE_ON_TRAFFIC_BUBBLE] ?: false
                 val isShowingDataBalanceOnTrafficBubble =
                     preferences[AppPreferencesKeys.IS_SHOWING_DATA_BALANCE_ON_TRAFFIC_BUBBLE] ?: false
+                val isShowingTrafficSpeedBubble =
+                    preferences[AppPreferencesKeys.IS_SHOWING_TRAFFIC_SPEED_BUBBLE] ?: false
                 val isIntroOpened = preferences[AppPreferencesKeys.IS_INTRO_OPENED] ?: false
 
                 AppSettings(
@@ -63,6 +65,7 @@ open class AppPreferencesManager(
                     isShowingTrafficBubble = isShowingTrafficBubble,
                     isShowingAccountBalanceOnTrafficBubble = isShowingAccountBalanceOnTrafficBubble,
                     isShowingDataBalanceOnTrafficBubble = isShowingDataBalanceOnTrafficBubble,
+                    isShowingTrafficSpeedBubble = isShowingTrafficSpeedBubble,
                     isIntroOpened = isIntroOpened,
                 )
             }
@@ -99,6 +102,12 @@ open class AppPreferencesManager(
         }
     }
 
+    override suspend fun updateIsShowingTrafficSpeedBubble(isShowingTrafficSpeedBubble: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[AppPreferencesKeys.IS_SHOWING_TRAFFIC_SPEED_BUBBLE] = isShowingTrafficSpeedBubble
+        }
+    }
+
     override suspend fun updateIsIntroOpened(isIntroOpened: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[AppPreferencesKeys.IS_INTRO_OPENED] = isIntroOpened
@@ -113,5 +122,6 @@ private object AppPreferencesKeys {
     val IS_SHOWING_ACCOUNT_BALANCE_ON_TRAFFIC_BUBBLE =
         booleanPreferencesKey("IS_SHOWING_ACCOUNT_BALANCE_ON_TRAFFIC_BUBBLE")
     val IS_SHOWING_DATA_BALANCE_ON_TRAFFIC_BUBBLE = booleanPreferencesKey("IS_SHOWING_DATA_BALANCE_ON_TRAFFIC_BUBBLE")
+    val IS_SHOWING_TRAFFIC_SPEED_BUBBLE = booleanPreferencesKey("IS_SHOWING_TRAFFIC_SPEED_BUBBLE")
     val IS_INTRO_OPENED = booleanPreferencesKey("IS_INTRO_OPENED")
 }

--- a/app/src/main/java/com/marlon/portalusuario/data/preferences/IAppPreferencesManager.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/preferences/IAppPreferencesManager.kt
@@ -17,5 +17,7 @@ interface IAppPreferencesManager {
 
     suspend fun updateIsShowingTrafficBubble(value: Boolean)
 
+    suspend fun updateIsShowingTrafficSpeedBubble(value: Boolean)
+
     suspend fun updateIsIntroOpened(value: Boolean)
 }

--- a/app/src/main/java/com/marlon/portalusuario/domain/model/AppSettings.kt
+++ b/app/src/main/java/com/marlon/portalusuario/domain/model/AppSettings.kt
@@ -6,5 +6,6 @@ data class AppSettings(
     val isShowingTrafficBubble: Boolean = false,
     val isShowingAccountBalanceOnTrafficBubble: Boolean = false,
     val isShowingDataBalanceOnTrafficBubble: Boolean = false,
+    val isShowingTrafficSpeedBubble: Boolean = false,
     val isIntroOpened: Boolean = false,
 )

--- a/app/src/main/java/com/marlon/portalusuario/erroreslog/JCLogging.kt
+++ b/app/src/main/java/com/marlon/portalusuario/erroreslog/JCLogging.kt
@@ -3,7 +3,7 @@ package com.marlon.portalusuario.erroreslog
 import android.content.Context
 import android.os.Environment
 import android.util.Log
-import androidx.preference.PreferenceManager
+import com.marlon.portalusuario.data.preferences.saveLogsFlow
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.File
@@ -13,6 +13,8 @@ import java.io.IOException
 import java.io.PrintWriter
 import java.text.SimpleDateFormat
 import java.util.Date
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import java.util.Locale
 
 object JCLogging {
@@ -143,8 +145,7 @@ object JCLogging {
         if (PRINT_ON_FILE) {
             val ctx = context ?: return
             try {
-                val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
-                if (prefs.getBoolean("save_logs", true)) {
+                if (runBlocking { ctx.saveLogsFlow().first() }) {
                     val formatString = "%s | %c | %s: %s\n"
                     writer?.format(formatString, DATE_FORMAT.format(Date()), type, resolvedMsg, resolvedObj)
                     if (type == 'E' && th != null) {

--- a/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
+++ b/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
@@ -17,7 +17,6 @@ import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
@@ -25,17 +24,17 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.activities.MainActivity
+import com.marlon.portalusuario.data.preferences.showNotificationsFlow
+import com.marlon.portalusuario.data.preferences.storageAdsFlow
 import com.marlon.portalusuario.punotifications.PUNotification
 import com.marlon.portalusuario.punotifications.PUNotificationsActivity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.io.FileOutputStream
 import java.util.GregorianCalendar
 
 class FirebaseService : FirebaseMessagingService() {
-    private val sharedPreferences by lazy {
-        PreferenceManager.getDefaultSharedPreferences(applicationContext)
-    }
-
     override fun onNewToken(token: String) {
         super.onNewToken(token)
     }
@@ -59,7 +58,7 @@ class FirebaseService : FirebaseMessagingService() {
                 ex.printStackTrace()
             }
 
-            val storageADS = sharedPreferences.getBoolean("storage_ads", true)
+            val storageADS = runBlocking { storageAdsFlow().first() }
             Log.e("STORAGE ADS", storageADS.toString())
 
             val title = notification.title ?: ""
@@ -123,7 +122,7 @@ class FirebaseService : FirebaseMessagingService() {
 
     @Suppress("DEPRECATION")
     private fun sendNotification(pun: PUNotification) {
-        if (!sharedPreferences.getBoolean("show_notifications", true)) return
+        if (!runBlocking { showNotificationsFlow().first() }) return
 
         val resultIntent = Intent(this, PUNotificationsActivity::class.java)
         val stackBuilder = TaskStackBuilder.create(this)


### PR DESCRIPTION
Migrates deprecated `PreferenceManager.getDefaultSharedPreferences` to modern DataStore.

## Changes
- **New**: `AppDataStore.kt` — DataStore wrapper for legacy preferences (show_notifications, save_logs, storage_ads, notifications_count)
- **FirebaseService.kt**: replaced sharedPreferences with DataStore + coroutines
- **JCLogging.kt**: replaced PreferenceManager with DataStore
- **PunRepositoryImpl.kt**: replaced PreferenceManager with DataStore
- **MainActivity.kt**: removed SharedPreferences listener, migrated show_traffic_speed_bubble → AppSettings.isShowingTrafficSpeedBubble
- **AppSettings**: added isShowingTrafficSpeedBubble field
- **AppPreferencesManager**: added updateIsShowingTrafficSpeedBubble
- Removed all `import androidx.preference.PreferenceManager` and `import android.content.SharedPreferences`

Closes #280