### PR TITLE
chore: remove legacy dependencies (#283)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,8 +170,6 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.jwtdecode)
     implementation(libs.prettytime)
-    implementation(libs.swipetoaction.library)
-    implementation(libs.ui.library)
 
     // ── Testing ──
     testImplementation(libs.junit)

--- a/app/src/main/java/com/marlon/portalusuario/components/SetLTEModeDialog.kt
+++ b/app/src/main/java/com/marlon/portalusuario/components/SetLTEModeDialog.kt
@@ -4,14 +4,14 @@ import android.app.Activity
 import android.app.Dialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.util.Log
 import android.view.Window
 import android.widget.Toast
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.databinding.DialogSetOnlyLteBinding
-import com.vanniktech.ui.Color
-import com.vanniktech.ui.ColorDrawable
 
 class SetLTEModeDialog(
     private val activity: Activity,

--- a/app/src/main/java/com/marlon/portalusuario/data/notifications/PunRepositoryImpl.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/notifications/PunRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.marlon.portalusuario.data.notifications
 import android.content.Context
 import android.widget.Toast
 import com.marlon.portalusuario.data.ServicesDao
-import com.marlon.portalusuario.data.notifications.PunRepositoryImpl.Companion.NOTIFICATIONS_COUNT_KEY
 import com.marlon.portalusuario.data.preferences.notificationsCountFlow
 import com.marlon.portalusuario.data.preferences.setNotificationsCount
 import com.marlon.portalusuario.domain.data.PunRepository
@@ -49,9 +48,5 @@ class PunRepositoryImpl
 
         override suspend fun deleteAllPUNotifications() {
             dao.deleteAllPUNotifications()
-        }
-
-        companion object {
-            const val NOTIFICATIONS_COUNT_KEY = "notifications_count"
         }
     }

--- a/app/src/main/java/com/marlon/portalusuario/punotifications/PUNotificationsActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/punotifications/PUNotificationsActivity.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import co.dift.ui.SwipeToAction
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.util.Util
 import com.marlon.portalusuario.viewmodel.PunViewModel
@@ -69,18 +68,5 @@ class PUNotificationsActivity : AppCompatActivity() {
         val punAdapter = PUNAdapter(notifications, this)
         recyclerView.adapter = punAdapter
         recyclerView.scheduleLayoutAnimation()
-
-        SwipeToAction(
-            recyclerView,
-            object : SwipeToAction.SwipeListener<PUNAdapter> {
-                override fun swipeLeft(itemData: PUNAdapter): Boolean = true
-
-                override fun swipeRight(itemData: PUNAdapter): Boolean = true
-
-                override fun onClick(itemData: PUNAdapter) {}
-
-                override fun onLongClick(itemData: PUNAdapter) {}
-            },
-        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,8 +84,6 @@ glide = "4.15.1"
 gson = "2.11.0"
 jwtdecode = "2.0.2"
 prettytime = "5.0.9.Final"
-co-library = "1.1"       # swipetoaction (legacy)
-ui-library = "0.5.0"     # vanniktech (legacy)
 
 # ═══════════════════════════════════════════
 # Testing
@@ -207,10 +205,6 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 jwtdecode = { group = "com.auth0.android", name = "jwtdecode", version.ref = "jwtdecode" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 prettytime = { group = "org.ocpsoft.prettytime", name = "prettytime", version.ref = "prettytime" }
-
-# ─── Legacy UI (pendiente de migrar) ───
-swipetoaction-library = { group = "co.dift.ui.swipetoaction", name = "library", version.ref = "co-library" }
-ui-library = { group = "com.vanniktech", name = "ui", version.ref = "ui-library" }
 
 # ─────────────────────────────────────────────
 # Testing


### PR DESCRIPTION
Removes two legacy/unmaintained dependencies:

- **swipetoaction** (`co.dift.ui.swipetoaction`): SwipeToAction was a no-op (both swipe callbacks returned true, clicks were empty). Removed entirely.
- **vanniktech** (`com.vanniktech:ui`): Replaced `Color`/`ColorDrawable` with `android.graphics.Color`/`android.graphics.drawable.ColorDrawable`.
- Cleaned up `NOTIFICATIONS_COUNT_KEY` constant no longer needed after DataStore migration.

Closes #283