### PR TITLE
fix: eliminar runBlocking en produccion (#276)

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/data/mappers/MobServiceApiToEntityMapper.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/mappers/MobServiceApiToEntityMapper.kt
@@ -4,17 +4,19 @@ import com.marlon.portalusuario.data.preferences.IMobServicesPreferences
 import com.marlon.portalusuario.domain.model.ServiceType
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import com.marlon.portalusuario.data.entity.MobileService as MobEntity
 import io.github.suitetecsa.sdk.nauta.model.MobileService as MobApi
+import com.marlon.portalusuario.data.entity.MobileService as MobEntity
 
 class MobServiceApiToEntityMapper(
-    private val preferences: IMobServicesPreferences,
+    preferences: IMobServicesPreferences,
     private val mobPlanMapper: MobPlanApiToModelMapper,
     private val mobBonusMapper: MobBonusApiToModelMapper,
 ) : Mapper<MobApi, MobEntity> {
+    private val slotIndexInfoList = runBlocking { preferences.preferences.first().slotIndexInfoList }
+
     override fun map(from: MobApi): MobEntity {
         val slotIndex =
-            runBlocking { preferences.preferences.first().slotIndexInfoList }
+            slotIndexInfoList
                 .firstOrNull { it.phoneNumber == from.profile.phoneNumber }
 
         return MobEntity(

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsState.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsState.kt
@@ -3,7 +3,7 @@ package com.marlon.portalusuario.feature.mobileservices.presentation.components.
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 data class ConfigSimCardsState(
-    val currentSimCard: SimCard,
+    val currentSimCard: SimCard? = null,
     val simCards: List<SimCard> = emptyList(),
     val isLoading: Boolean = false,
     val phoneNumber: String = "",

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsView.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsView.kt
@@ -4,16 +4,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -34,11 +37,21 @@ fun ConfigSimCardsView(
     onSetTitle: (String) -> Unit,
     onSetCanGoNext: (Boolean) -> Unit,
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val pagerState = rememberPagerState { state.viewModel.state.simCards.size }
+    val viewState = state.viewModel.state
+    val currentSimCard = viewState.currentSimCard
 
-    LaunchedEffect(state.viewModel.state.isLoading) {
-        onSetIsLoading(state.viewModel.state.isLoading)
+    if (currentSimCard == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    val coroutineScope = rememberCoroutineScope()
+    val pagerState = rememberPagerState { viewState.simCards.size }
+
+    LaunchedEffect(viewState.isLoading) {
+        onSetIsLoading(viewState.isLoading)
     }
 
     LaunchedEffect(state.viewModel.isPhoneNumberValid) {
@@ -47,23 +60,18 @@ fun ConfigSimCardsView(
 
     HorizontalPager(state = pagerState, userScrollEnabled = false) {
         ServiceSettingsView(
-            simCard = state.viewModel.state.currentSimCard,
-            phoneNumber = state.viewModel.state.phoneNumber,
-            isLoading = state.viewModel.state.isLoading,
+            simCard = currentSimCard,
+            phoneNumber = viewState.phoneNumber,
+            isLoading = viewState.isLoading,
             onChangePhoneNumber = { state.viewModel.onEvent(ConfigSimCardsEvent.OnChangedPhoneNumber(it)) },
         )
     }
 
-    LaunchedEffect(key1 = state.viewModel.state.currentSimCard) {
-        onSetTitle("Configurar SIM${state.viewModel.state.currentSimCard.slotIndex + 1}")
-        if (state.viewModel.state.simCards
-                .indexOf(state.viewModel.state.currentSimCard) != pagerState.currentPage
-        ) {
+    LaunchedEffect(key1 = currentSimCard) {
+        onSetTitle("Configurar SIM${currentSimCard.slotIndex + 1}")
+        if (viewState.simCards.indexOf(currentSimCard) != pagerState.currentPage) {
             coroutineScope.launch {
-                pagerState.animateScrollToPage(
-                    state.viewModel.state.simCards
-                        .indexOf(state.viewModel.state.currentSimCard),
-                )
+                pagerState.animateScrollToPage(viewState.simCards.indexOf(currentSimCard))
             }
         }
     }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/configsimcards/ConfigSimCardsViewModel.kt
@@ -14,11 +14,11 @@ import io.github.suitetecsa.sdk.android.SimCardCollector
 import io.github.suitetecsa.sdk.android.model.SimCard
 import io.github.suitetecsa.sdk.android.utils.extractShortNumber
 import io.github.suitetecsa.sdk.android.utils.validateFormat
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 private const val TAG = "ConfigSimCardsViewModel"
@@ -31,17 +31,6 @@ class ConfigSimCardsViewModel
         private val repository: UserRepository,
         private val simCardCollector: SimCardCollector,
     ) : ViewModel() {
-        private val simCards: List<SimCard>
-            @SuppressLint("MissingPermission")
-            get() =
-                runBlocking {
-                    preferences.preferences.first().slotIndexInfoList.let { indexes ->
-                        simCardCollector.collect().filter {
-                            it.slotIndex !in indexes.map { index -> index.index }
-                        }
-                    }
-                }
-
         private val pref =
             preferences.preferences.stateIn(
                 viewModelScope,
@@ -49,28 +38,52 @@ class ConfigSimCardsViewModel
                 MobServPreferences(emptyList()),
             )
 
+        @SuppressLint("MissingPermission")
+        private suspend fun loadSimCards(): List<SimCard> {
+            val indexes = preferences.preferences.first().slotIndexInfoList
+            return simCardCollector.collect().filter {
+                it.slotIndex !in indexes.map { index -> index.index }
+            }
+        }
+
         private val _state =
             mutableStateOf(
-                ConfigSimCardsState(
-                    simCards.first(),
-                    simCards = simCards,
-                    phoneNumber = simCards.first().phoneNumber?.let { extractShortNumber(it) } ?: "",
-                ),
+                ConfigSimCardsState(),
             )
         val state get() = _state.value
 
         val isPhoneNumberValid: Boolean
             get() = validateFormat(_state.value.phoneNumber)?.length == 8
 
+        init {
+            viewModelScope.launch {
+                val cards = loadSimCards()
+                _state.value =
+                    ConfigSimCardsState(
+                        simCards = cards,
+                        currentSimCard = cards.first(),
+                        phoneNumber =
+                            cards.first().phoneNumber?.let { extractShortNumber(it) }
+                                ?: "",
+                    )
+            }
+        }
+
         fun onEvent(event: ConfigSimCardsEvent) {
             when (event) {
                 is ConfigSimCardsEvent.OnChangedPhoneNumber ->
                     _state.value = _state.value.copy(phoneNumber = event.value)
-                ConfigSimCardsEvent.OnNext ->
-                    _state.value =
-                        _state.value.copy(
-                            currentSimCard = simCards[simCards.indexOf(_state.value.currentSimCard) + 1],
-                        )
+                ConfigSimCardsEvent.OnNext -> {
+                    val cards = _state.value.simCards
+                    val current = _state.value.currentSimCard!!
+                    val idx = cards.indexOf(current)
+                    if (idx >= 0 && idx < cards.size - 1) {
+                        _state.value =
+                            _state.value.copy(
+                                currentSimCard = cards[idx + 1],
+                            )
+                    }
+                }
                 is ConfigSimCardsEvent.OnSimCardAdd ->
                     viewModelScope.launch {
                         if (isPhoneNumberValid) {
@@ -79,25 +92,25 @@ class ConfigSimCardsViewModel
                                 pref.value.slotIndexInfoList.toMutableList().apply {
                                     add(
                                         SlotIndexInfo(
-                                            _state.value.currentSimCard.slotIndex,
+                                            _state.value.currentSimCard!!!!.slotIndex,
                                             _state.value.phoneNumber,
                                         ),
                                     )
                                 },
                             )
                             repository.fetchUser(
-                                _state.value.currentSimCard.copy(phoneNumber = _state.value.phoneNumber),
+                                _state.value.currentSimCard!!.copy(phoneNumber = _state.value.phoneNumber),
                             )
                             Log.d(
                                 TAG,
-                                "onEvent: current slotIndex :: ${_state.value.currentSimCard.slotIndex}",
+                                "onEvent: current slotIndex :: ${_state.value.currentSimCard!!.slotIndex}",
                             )
                             Log.d(
                                 TAG,
                                 "onEvent: last slotIndex :: ${_state.value.simCards.last().slotIndex}",
                             )
                             _state.value = _state.value.copy(isLoading = false)
-                            if (_state.value.currentSimCard.slotIndex ==
+                            if (_state.value.currentSimCard!!.slotIndex ==
                                 _state.value.simCards
                                     .last()
                                     .slotIndex


### PR DESCRIPTION
Elimina usos de `runBlocking` en:

- **MobServiceApiToEntityMapper**: movido de `map()` (ejecutado N veces) a `init` (una vez por instancia DI)
- **ConfigSimCardsViewModel**: reemplazado por función `suspend loadSimCards()` + inicialización asíncrona en `init` con `viewModelScope.launch`. Estado `ConfigSimCardsState` con `currentSimCard` nullable + loading indicator mientras se cargan las SIMs.

Closes #276