### PR TITLE
feat: migrar IntroActivity a ruta NavHost (#296)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -31,7 +31,6 @@
 # ============================================================
 # AndroidManifest components
 # ============================================================
--keep class com.marlon.portalusuario.intro.IntroActivity { *; }
 -keep class com.marlon.portalusuario.activities.MainActivity { *; }
 -keep class com.marlon.portalusuario.permisos.PermissionActivity { *; }
 -keep class com.marlon.portalusuario.punotifications.PUNotificationsActivity { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,12 +68,6 @@
         android:usesCleartextTraffic="true"
         tools:replace="android:icon">
         <activity
-            android:name=".intro.IntroActivity"
-            android:exported="false"
-            android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity">
-        </activity>
-        <activity
             android:name=".activities.MainActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"

--- a/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
@@ -1,11 +1,13 @@
 package com.marlon.portalusuario.activities
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
@@ -103,6 +105,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val startIntro = intent.getBooleanExtra("start_intro", false)
+        manageBatteryConsumption()
+
         lifecycleScope.launch {
             appPreferencesManager.preferences().collect { preferences ->
                 isDynamicColor = preferences.isDynamicColor
@@ -194,8 +199,20 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             PortalUsuarioTheme(dynamicColor = isDynamicColor) {
-                MainScreen()
+                MainScreen(startDestination = if (startIntro) Route.Intro.route else Route.MobileServices.route)
             }
+        }
+    }
+
+    private fun manageBatteryConsumption() {
+        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (!powerManager.isIgnoringBatteryOptimizations(packageName)) {
+            startActivity(
+                Intent().apply {
+                    action = android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+                    data = "package:$packageName".toUri()
+                },
+            )
         }
     }
 
@@ -211,7 +228,7 @@ class MainActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun MainScreen() {
+private fun MainScreen(startDestination: String = Route.MobileServices.route) {
     val navController = rememberNavController()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -282,7 +299,7 @@ private fun MainScreen() {
             PortalUsuarioNavHost(
                 navController = navController,
                 modifier = Modifier.padding(padding),
-                startDestination = Route.MobileServices.route,
+                startDestination = startDestination,
             )
         }
     }

--- a/app/src/main/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/splash/presentation/screen/SplashScreen.kt
@@ -31,7 +31,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.marlon.portalusuario.R
 import com.marlon.portalusuario.activities.MainActivity
 import com.marlon.portalusuario.feature.splash.presentation.SplashViewModel
-import com.marlon.portalusuario.intro.IntroActivity
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -83,13 +82,12 @@ fun SplashScreen(viewModel: SplashViewModel = hiltViewModel()) {
             scope.launch {
                 delay(MIN_TIME)
                 preference?.also {
-                    if (!it.isIntroOpened) {
-                        context.startActivity(Intent(context, IntroActivity::class.java))
-                        (context as Activity).finish()
-                    } else {
-                        context.startActivity(Intent(context, MainActivity::class.java))
-                        (context as Activity).finish()
-                    }
+                    val intent =
+                        Intent(context, MainActivity::class.java).apply {
+                            putExtra("start_intro", !it.isIntroOpened)
+                        }
+                    context.startActivity(intent)
+                    (context as Activity).finish()
                 }
             }
         }

--- a/app/src/main/java/com/marlon/portalusuario/intro/IntroActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/intro/IntroActivity.kt
@@ -1,11 +1,5 @@
 package com.marlon.portalusuario.intro
 
-import android.content.Context
-import android.content.Intent
-import android.os.Bundle
-import android.os.PowerManager
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -36,58 +30,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
-import androidx.lifecycle.lifecycleScope
 import com.marlon.portalusuario.R
-import com.marlon.portalusuario.data.preferences.IAppPreferencesManager
-import com.marlon.portalusuario.permisos.PermissionActivity
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 data class ScreenItem(
     val title: String,
     val description: String,
     val screenImg: Int,
 )
-
-@AndroidEntryPoint
-class IntroActivity : ComponentActivity() {
-    @Inject
-    lateinit var appPreferencesManager: IAppPreferencesManager
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        manageBatteryConsumption()
-
-        setContent {
-            IntroScreen {
-                savePrefsData()
-                startActivity(Intent(this, PermissionActivity::class.java))
-                finish()
-            }
-        }
-    }
-
-    private fun manageBatteryConsumption() {
-        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
-        if (!powerManager.isIgnoringBatteryOptimizations(packageName)) {
-            startActivity(
-                Intent().apply {
-                    action = android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-                    data = "package:$packageName".toUri()
-                },
-            )
-        }
-    }
-
-    private fun savePrefsData() {
-        lifecycleScope.launch {
-            appPreferencesManager.updateIsIntroOpened(true)
-        }
-    }
-}
 
 @Composable
 fun IntroScreen(onGetStarted: () -> Unit) {

--- a/app/src/main/java/com/marlon/portalusuario/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/intro/IntroViewModel.kt
@@ -1,0 +1,21 @@
+package com.marlon.portalusuario.intro
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.marlon.portalusuario.data.preferences.IAppPreferencesManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class IntroViewModel
+    @Inject
+    constructor(
+        private val appPreferencesManager: IAppPreferencesManager,
+    ) : ViewModel() {
+        fun onIntroCompleted() {
+            viewModelScope.launch {
+                appPreferencesManager.updateIsIntroOpened(true)
+            }
+        }
+    }

--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -25,6 +26,8 @@ import com.marlon.portalusuario.feature.telephony.presentation.EmergencyCallsScr
 import com.marlon.portalusuario.feature.telephony.presentation.PrivateCallScreen
 import com.marlon.portalusuario.feature.telephony.presentation.SmsScreen
 import com.marlon.portalusuario.feature.telephony.presentation.VozScreen
+import com.marlon.portalusuario.intro.IntroScreen
+import com.marlon.portalusuario.intro.IntroViewModel
 import com.marlon.portalusuario.paquetes.PaquetesScreen
 import com.marlon.portalusuario.perfil.PerfilScreen
 import com.marlon.portalusuario.servicios.ServiciosScreen
@@ -47,7 +50,17 @@ fun PortalUsuarioNavHost(
         modifier = modifier,
     ) {
         composable(Route.Splash.route) { PlaceholderScreen("Splash") }
-        composable(Route.Intro.route) { PlaceholderScreen("Intro") }
+        composable(Route.Intro.route) {
+            val viewModel: IntroViewModel = hiltViewModel()
+            IntroScreen(
+                onGetStarted = {
+                    viewModel.onIntroCompleted()
+                    navController.navigate(Route.MobileServices.route) {
+                        popUpTo(Route.Intro.route) { inclusive = true }
+                    }
+                },
+            )
+        }
         composable(Route.Permissions.route) { PlaceholderScreen("Permissions") }
         composable(Route.Main.route) { MobileServicesScreen() }
         composable(Route.Settings.route) { SettingsScreen() }


### PR DESCRIPTION
Migra IntroActivity a una ruta dentro del NavHost centralizado usando Compose Navigation:

- Creado IntroViewModel con Hilt para guardar isIntroOpened
- SplashScreen ahora siempre lanza MainActivity con extra `start_intro`
- MainActivity lee el extra y pasa startDestination dinámico al NavHost
- NavHost reemplaza PlaceholderScreen("Intro") por IntroScreen real
- ManageBatteryConsumption movido a MainActivity.onCreate
- Eliminada IntroActivity (clase, AndroidManifest, proguard rule)

Build: ✅ `assembleDebug` exitoso