### PR TITLE
feat: migrar PermissionActivity a ruta NavHost (#297)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,7 +32,6 @@
 # AndroidManifest components
 # ============================================================
 -keep class com.marlon.portalusuario.activities.MainActivity { *; }
--keep class com.marlon.portalusuario.permisos.PermissionActivity { *; }
 -keep class com.marlon.portalusuario.punotifications.PUNotificationsActivity { *; }
 -keep class com.marlon.portalusuario.erroreslog.LogFileViewerActivity { *; }
 -keep class com.marlon.portalusuario.feature.splash.presentation.ActivitySplash { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,9 +73,6 @@
             android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity" />
         <activity
-            android:name=".permisos.PermissionActivity"
-            android:exported="true" />
-        <activity
             android:name=".punotifications.PUNotificationsActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
@@ -88,6 +88,7 @@ import com.marlon.portalusuario.viewmodel.PunViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import androidx.compose.ui.res.stringResource
 
 private const val TAG = "MainActivity"
 
@@ -106,6 +107,14 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val startIntro = intent.getBooleanExtra("start_intro", false)
+        val permissionsMissing =
+            hasPermissions(
+                Manifest.permission.CALL_PHONE,
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_CONTACTS,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            )
         manageBatteryConsumption()
 
         lifecycleScope.launch {
@@ -179,27 +188,17 @@ class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        if (hasPermissions(
-                Manifest.permission.CALL_PHONE,
-                Manifest.permission.CAMERA,
-                Manifest.permission.READ_CONTACTS,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-                Manifest.permission.ACCESS_FINE_LOCATION,
-            )
-        ) {
-            startActivity(
-                Intent(
-                    this,
-                    com.marlon.portalusuario.permisos.PermissionActivity::class.java,
-                ),
-            )
-        }
-
         punViewModel = ViewModelProvider(this)[PunViewModel::class.java]
 
         setContent {
             PortalUsuarioTheme(dynamicColor = isDynamicColor) {
-                MainScreen(startDestination = if (startIntro) Route.Intro.route else Route.MobileServices.route)
+                val startDestination =
+                    when {
+                        startIntro -> Route.Intro.route
+                        permissionsMissing -> Route.Permissions.route
+                        else -> Route.MobileServices.route
+                    }
+                MainScreen(startDestination = startDestination)
             }
         }
     }
@@ -342,7 +341,7 @@ private fun DrawerContent(
     onItemClick: (DrawerAction) -> Unit,
 ) {
     val context = LocalContext.current
-    val inviteText = context.getString(R.string.invite_user)
+    val inviteText = stringResource(R.string.invite_user)
     val versionName =
         try {
             @Suppress("DEPRECATION")

--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -30,6 +30,8 @@ import com.marlon.portalusuario.intro.IntroScreen
 import com.marlon.portalusuario.intro.IntroViewModel
 import com.marlon.portalusuario.paquetes.PaquetesScreen
 import com.marlon.portalusuario.perfil.PerfilScreen
+import com.marlon.portalusuario.permisos.PermissionScreen
+import com.marlon.portalusuario.permisos.PermissionViewModel
 import com.marlon.portalusuario.servicios.ServiciosScreen
 import com.marlon.portalusuario.une.UneScreen
 
@@ -55,13 +57,23 @@ fun PortalUsuarioNavHost(
             IntroScreen(
                 onGetStarted = {
                     viewModel.onIntroCompleted()
-                    navController.navigate(Route.MobileServices.route) {
+                    navController.navigate(Route.Permissions.route) {
                         popUpTo(Route.Intro.route) { inclusive = true }
                     }
                 },
             )
         }
-        composable(Route.Permissions.route) { PlaceholderScreen("Permissions") }
+        composable(Route.Permissions.route) {
+            val viewModel: PermissionViewModel = hiltViewModel()
+            PermissionScreen(
+                viewModel = viewModel,
+                onFinish = {
+                    navController.navigate(Route.MobileServices.route) {
+                        popUpTo(Route.Permissions.route) { inclusive = true }
+                    }
+                },
+            )
+        }
         composable(Route.Main.route) { MobileServicesScreen() }
         composable(Route.Settings.route) { SettingsScreen() }
         composable(Route.About.route) { AboutScreen() }

--- a/app/src/main/java/com/marlon/portalusuario/permisos/PermissionActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/permisos/PermissionActivity.kt
@@ -2,11 +2,8 @@ package com.marlon.portalusuario.permisos
 
 import android.Manifest
 import android.content.Intent
-import android.os.Bundle
 import android.provider.Settings
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -31,20 +28,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
-import com.marlon.portalusuario.activities.MainActivity
-
-class PermissionActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val viewModel = PermissionViewModel()
-        setContent {
-            PermissionScreen(viewModel)
-        }
-    }
-}
 
 @Composable
-fun PermissionScreen(viewModel: PermissionViewModel) {
+fun PermissionScreen(
+    viewModel: PermissionViewModel,
+    onFinish: () -> Unit,
+) {
     val context = LocalContext.current
 
     val callPermissionLauncher =
@@ -123,10 +112,7 @@ fun PermissionScreen(viewModel: PermissionViewModel) {
                             )
                         overlayPermissionLauncher.launch(intent)
                     },
-                    onFinish = {
-                        context.startActivity(Intent(context, MainActivity::class.java))
-                        (context as ComponentActivity).finish()
-                    },
+                    onFinish = onFinish,
                 )
             }
         }
@@ -193,5 +179,5 @@ fun PermissionSteps(
 @Preview(showBackground = true)
 @Composable
 fun PermissionScreenPreview() {
-    PermissionScreen(PermissionViewModel())
+    PermissionScreen(PermissionViewModel()) {}
 }

--- a/app/src/main/java/com/marlon/portalusuario/permisos/PermissionViewModel.kt
+++ b/app/src/main/java/com/marlon/portalusuario/permisos/PermissionViewModel.kt
@@ -4,18 +4,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class PermissionViewModel : ViewModel() {
-    var currentStep by mutableIntStateOf(0)
-        private set
+@HiltViewModel
+class PermissionViewModel
+    @Inject
+    constructor() : ViewModel() {
+        var currentStep by mutableIntStateOf(0)
+            private set
 
-    fun nextStep() {
-        currentStep++
-    }
+        fun nextStep() {
+            currentStep++
+        }
 
-    fun onOverlayPermissionResult(canDrawOverlays: Boolean) {
-        if (canDrawOverlays) {
-            nextStep()
+        fun onOverlayPermissionResult(canDrawOverlays: Boolean) {
+            if (canDrawOverlays) {
+                nextStep()
+            }
         }
     }
-}


### PR DESCRIPTION
Migra PermissionActivity a una ruta dentro del NavHost centralizado:

- PermissionViewModel convertido a @HiltViewModel
- PermissionScreen acepta onFinish callback en vez de hardcodear MainActivity
- Navigation.kt reemplaza PlaceholderScreen("Permissions") por PermissionScreen real
- Intro ahora navega a Permissions en vez de MobileServices
- MainActivity determina startDestination según permisos faltantes (sin launchActivity)
- Eliminada PermissionActivity (clase, AndroidManifest, proguard rule)

Build: ✅ assembleDebug exitoso