### PR TITLE
feat: migrar PUNotificationsActivity a ruta NavHost (#299)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,7 @@ dependencies {
 
     // ── Image Loading ──
     implementation(libs.glide)
+    implementation(libs.coil.compose)
 
     // ── Utilities ──
     implementation(libs.caverock.androidsvg.aar)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,7 +32,6 @@
 # AndroidManifest components
 # ============================================================
 -keep class com.marlon.portalusuario.activities.MainActivity { *; }
--keep class com.marlon.portalusuario.punotifications.PUNotificationsActivity { *; }
 -keep class com.marlon.portalusuario.feature.splash.presentation.ActivitySplash { *; }
 -keep class com.marlon.portalusuario.firebase.FirebaseService { *; }
 -keep class com.marlon.portalusuario.trafficbubble.FloatingBubbleService { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,9 +73,6 @@
             android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity" />
         <activity
-            android:name=".punotifications.PUNotificationsActivity"
-            android:exported="false" />
-        <activity
             android:name=".feature.splash.presentation.ActivitySplash"
             android:exported="true"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/activities/MainActivity.kt
@@ -70,7 +70,6 @@ import androidx.compose.ui.unit.sp
 import androidx.core.app.ShareCompat
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -84,7 +83,6 @@ import com.marlon.portalusuario.trafficbubble.FloatingBubbleService
 import com.marlon.portalusuario.ui.theme.PortalUsuarioTheme
 import com.marlon.portalusuario.util.NetworkConnectivityObserver
 import com.marlon.portalusuario.util.Utils.hasPermissions
-import com.marlon.portalusuario.viewmodel.PunViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -107,6 +105,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val startIntro = intent.getBooleanExtra("start_intro", false)
+        val openNotifications = intent.getBooleanExtra("open_notifications", false)
         val permissionsMissing =
             hasPermissions(
                 Manifest.permission.CALL_PHONE,
@@ -188,12 +187,11 @@ class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        punViewModel = ViewModelProvider(this)[PunViewModel::class.java]
-
         setContent {
             PortalUsuarioTheme(dynamicColor = isDynamicColor) {
                 val startDestination =
                     when {
+                        openNotifications -> Route.PUNotifications.createRoute()
                         startIntro -> Route.Intro.route
                         permissionsMissing -> Route.Permissions.route
                         else -> Route.MobileServices.route
@@ -212,15 +210,6 @@ class MainActivity : ComponentActivity() {
                     data = "package:$packageName".toUri()
                 },
             )
-        }
-    }
-
-    companion object {
-        private var punViewModel: PunViewModel? = null
-
-        @JvmStatic
-        fun insertNotification() {
-            punViewModel!!.insertPUN(null)
         }
     }
 }

--- a/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
+++ b/app/src/main/java/com/marlon/portalusuario/firebase/FirebaseService.kt
@@ -26,15 +26,21 @@ import com.marlon.portalusuario.R
 import com.marlon.portalusuario.activities.MainActivity
 import com.marlon.portalusuario.data.preferences.showNotificationsFlow
 import com.marlon.portalusuario.data.preferences.storageAdsFlow
+import com.marlon.portalusuario.domain.data.PunRepository
 import com.marlon.portalusuario.punotifications.PUNotification
-import com.marlon.portalusuario.punotifications.PUNotificationsActivity
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.io.FileOutputStream
 import java.util.GregorianCalendar
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class FirebaseService : FirebaseMessagingService() {
+    @Inject
+    lateinit var punRepository: PunRepository
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
     }
@@ -114,7 +120,7 @@ class FirebaseService : FirebaseMessagingService() {
                         ex.printStackTrace()
                     }
                 }
-                MainActivity.insertNotification()
+                runBlocking { punRepository.insertPUNotification(pun) }
             }
             sendNotification(pun)
         }
@@ -124,7 +130,10 @@ class FirebaseService : FirebaseMessagingService() {
     private fun sendNotification(pun: PUNotification) {
         if (!runBlocking { showNotificationsFlow().first() }) return
 
-        val resultIntent = Intent(this, PUNotificationsActivity::class.java)
+        val resultIntent =
+            Intent(this, MainActivity::class.java).apply {
+                putExtra("open_notifications", true)
+            }
         val stackBuilder = TaskStackBuilder.create(this)
         stackBuilder.addNextIntentWithParentStack(resultIntent)
         val resultPendingIntent =

--- a/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/navigation/Navigation.kt
@@ -33,6 +33,7 @@ import com.marlon.portalusuario.paquetes.PaquetesScreen
 import com.marlon.portalusuario.perfil.PerfilScreen
 import com.marlon.portalusuario.permisos.PermissionScreen
 import com.marlon.portalusuario.permisos.PermissionViewModel
+import com.marlon.portalusuario.punotifications.PUNotificationsScreen
 import com.marlon.portalusuario.servicios.ServiciosScreen
 import com.marlon.portalusuario.une.UneScreen
 
@@ -109,9 +110,8 @@ fun PortalUsuarioNavHost(
                         defaultValue = ""
                     },
                 ),
-        ) { backStackEntry ->
-            val notificationId = backStackEntry.arguments?.getString("notificationId") ?: ""
-            PlaceholderScreen("PU Notifications (id=$notificationId)")
+        ) { _ ->
+            PUNotificationsScreen()
         }
     }
 }

--- a/app/src/main/java/com/marlon/portalusuario/punotifications/PUNotificationsScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/punotifications/PUNotificationsScreen.kt
@@ -1,0 +1,211 @@
+package com.marlon.portalusuario.punotifications
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.marlon.portalusuario.util.Util
+import com.marlon.portalusuario.viewmodel.PunViewModel
+
+@Composable
+fun PUNotificationsScreen(viewModel: PunViewModel = hiltViewModel()) {
+    val notifications by viewModel.allPUN.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val isConnected = remember { Util.isConnected(context) }
+
+    LazyColumn(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            StatusHeader(isConnected = isConnected)
+        }
+
+        if (notifications.isEmpty()) {
+            item {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No hay notificaciones",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        items(notifications, key = { it.id }) { notification ->
+            NotificationCard(notification = notification)
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun StatusHeader(isConnected: Boolean) {
+    val statusColor =
+        if (isConnected) Color(0xFF4CAF50) else Color(0xFFF44336)
+    val statusText = if (isConnected) "En línea" else "Desconectado"
+
+    Row(
+        modifier = Modifier.padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(10.dp)
+                    .clip(CircleShape)
+                    .background(statusColor),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = statusText,
+            fontSize = 14.sp,
+            color = Color.Gray,
+        )
+    }
+}
+
+@Composable
+private fun NotificationCard(notification: PUNotification) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable { isExpanded = !isExpanded },
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = notification.title.firstOrNull()?.uppercase() ?: "P",
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = notification.title.ifEmpty { "Portal Usuario anuncia...!" },
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = notification.dateToString(),
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                    )
+                }
+                IconButton(onClick = { isExpanded = !isExpanded }) {
+                    Icon(
+                        imageVector =
+                            if (isExpanded) Icons.Default.KeyboardArrowUp
+                            else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (isExpanded) "Contraer" else "Expandir",
+                    )
+                }
+            }
+
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Column(modifier = Modifier.padding(top = 8.dp)) {
+                    if (notification.image.isNotEmpty()) {
+                        AsyncImage(
+                            model = notification.image,
+                            contentDescription = null,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .height(200.dp)
+                                    .clip(RoundedCornerShape(8.dp)),
+                            contentScale = ContentScale.Crop,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    Text(
+                        text = notification.text.ifEmpty { "Sin detalles" },
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,11 @@ jwtdecode = "2.0.2"
 prettytime = "5.0.9.Final"
 
 # ═══════════════════════════════════════════
+# Compose Image Loading
+# ═══════════════════════════════════════════
+coil = "2.7.0"
+
+# ═══════════════════════════════════════════
 # Testing
 # ═══════════════════════════════════════════
 junit = "4.13.2"
@@ -205,6 +210,11 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 jwtdecode = { group = "com.auth0.android", name = "jwtdecode", version.ref = "jwtdecode" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 prettytime = { group = "org.ocpsoft.prettytime", name = "prettytime", version.ref = "prettytime" }
+
+# ─────────────────────────────────────────────
+# Compose Image Loading
+# ─────────────────────────────────────────────
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 # ─────────────────────────────────────────────
 # Testing


### PR DESCRIPTION
Migra PUNotificationsActivity a una ruta Compose dentro del NavHost:

- Agregada dependencia coil-compose 2.7.0 para carga de imagenes en Compose
- Creado PUNotificationsScreen con LazyColumn y tarjetas expandibles (animadas)
- Cada notificacion muestra icono circular con inicial, titulo, fecha, flecha expandir
- Expandido: imagen via AsyncImage (Coil) y texto descriptivo
- Indicador de estado online/offline en el encabezado
- Navigation.kt reemplaza PlaceholderScreen por PUNotificationsScreen real
- FirebaseService ahora inyecta PunRepository via Hilt (@AndroidEntryPoint)
- Notificaciones push abren MainActivity con extra open_notifications en vez de PUNotificationsActivity
- MainActivity navega directamente a PUNotifications cuando llega desde push
- Eliminado companion object buggy insertNotification() de MainActivity
- Eliminada PUNotificationsActivity del AndroidManifest y proguard

Build: ✅ assembleDebug exitoso