### PR TITLE
fix: columnas NOT NULL faltantes en MIGRATION_1_2 causan crash en Room validation

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/core/di/AppModule.kt
+++ b/app/src/main/java/com/marlon/portalusuario/core/di/AppModule.kt
@@ -59,7 +59,7 @@ class AppModule {
             context,
             ServicesDB::class.java,
             "services_db",
-        ).addMigrations(ServicesDB.MIGRATION_1_2)
+        ).addMigrations(ServicesDB.MIGRATION_1_2, ServicesDB.MIGRATION_2_3)
         .build()
 
     @Singleton

--- a/app/src/main/java/com/marlon/portalusuario/data/ServicesDB.kt
+++ b/app/src/main/java/com/marlon/portalusuario/data/ServicesDB.kt
@@ -22,7 +22,7 @@ import com.marlon.portalusuario.feature.une.Une
         Une::class,
         PUNotification::class,
     ],
-    version = 2,
+    version = 3,
 )
 @TypeConverters(Converters::class)
 abstract class ServicesDB : RoomDatabase() {
@@ -35,48 +35,68 @@ abstract class ServicesDB : RoomDatabase() {
                     db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS `user` (
-                            `id` INTEGER PRIMARY KEY AUTOINCREMENT,
-                            `username` TEXT,
-                            `password` TEXT,
-                            `nautaEmailPassword` TEXT,
-                            `attributeUuid` TEXT,
-                            `csrfhw` TEXT,
-                            `accountNavegationType` INTEGER,
-                            `leftTime` TEXT,
-                            `accountCredit` TEXT,
-                            `accountState` TEXT,
-                            `lastConnectionDateTime` INTEGER,
-                            `blockDate` TEXT,
-                            `delDate` TEXT,
-                            `accountType` TEXT,
-                            `serviceType` TEXT,
-                            `emailAccount` TEXT
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `username` TEXT NOT NULL,
+                            `password` TEXT NOT NULL,
+                            `nautaEmailPassword` TEXT NOT NULL,
+                            `attributeUuid` TEXT NOT NULL,
+                            `csrfhw` TEXT NOT NULL,
+                            `accountNavegationType` INTEGER NOT NULL,
+                            `leftTime` TEXT NOT NULL,
+                            `accountCredit` TEXT NOT NULL,
+                            `accountState` TEXT NOT NULL,
+                            `lastConnectionDateTime` INTEGER NOT NULL,
+                            `blockDate` TEXT NOT NULL,
+                            `delDate` TEXT NOT NULL,
+                            `accountType` TEXT NOT NULL,
+                            `serviceType` TEXT NOT NULL,
+                            `emailAccount` TEXT NOT NULL
                         )
                         """.trimIndent(),
                     )
                     db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS `une` (
-                            `id` INTEGER PRIMARY KEY AUTOINCREMENT,
-                            `date` INTEGER,
-                            `lastRegister` REAL,
-                            `currentRegister` REAL,
-                            `totalConsumption` REAL,
-                            `totalToPay` REAL
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `date` INTEGER NOT NULL,
+                            `lastRegister` REAL NOT NULL,
+                            `currentRegister` REAL NOT NULL,
+                            `totalConsumption` REAL NOT NULL,
+                            `totalToPay` REAL NOT NULL
                         )
                         """.trimIndent(),
                     )
                     db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS `notifications` (
-                            `id` INTEGER PRIMARY KEY AUTOINCREMENT,
-                            `title` TEXT,
-                            `text` TEXT,
-                            `image` TEXT,
-                            `date` INTEGER
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `title` TEXT NOT NULL,
+                            `text` TEXT NOT NULL,
+                            `image` TEXT NOT NULL,
+                            `date` INTEGER NOT NULL
                         )
                         """.trimIndent(),
                     )
+                }
+            }
+
+        val MIGRATION_2_3 =
+            object : Migration(2, 3) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("CREATE TABLE IF NOT EXISTS `user_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `nautaEmailPassword` TEXT NOT NULL, `attributeUuid` TEXT NOT NULL, `csrfhw` TEXT NOT NULL, `accountNavegationType` INTEGER NOT NULL, `leftTime` TEXT NOT NULL, `accountCredit` TEXT NOT NULL, `accountState` TEXT NOT NULL, `lastConnectionDateTime` INTEGER NOT NULL, `blockDate` TEXT NOT NULL, `delDate` TEXT NOT NULL, `accountType` TEXT NOT NULL, `serviceType` TEXT NOT NULL, `emailAccount` TEXT NOT NULL)")
+                    db.execSQL("INSERT INTO `user_new` SELECT * FROM `user`")
+                    db.execSQL("DROP TABLE `user`")
+                    db.execSQL("ALTER TABLE `user_new` RENAME TO `user`")
+
+                    db.execSQL("CREATE TABLE IF NOT EXISTS `une_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date` INTEGER NOT NULL, `lastRegister` REAL NOT NULL, `currentRegister` REAL NOT NULL, `totalConsumption` REAL NOT NULL, `totalToPay` REAL NOT NULL)")
+                    db.execSQL("INSERT INTO `une_new` SELECT * FROM `une`")
+                    db.execSQL("DROP TABLE `une`")
+                    db.execSQL("ALTER TABLE `une_new` RENAME TO `une`")
+
+                    db.execSQL("CREATE TABLE IF NOT EXISTS `notifications_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `text` TEXT NOT NULL, `image` TEXT NOT NULL, `date` INTEGER NOT NULL)")
+                    db.execSQL("INSERT INTO `notifications_new` SELECT * FROM `notifications`")
+                    db.execSQL("DROP TABLE `notifications`")
+                    db.execSQL("ALTER TABLE `notifications_new` RENAME TO `notifications`")
                 }
             }
     }


### PR DESCRIPTION
## Problema

La migración `MIGRATION_1_2` (v1 → v2) crea las tablas `user`, `une` y `notifications` sin `NOT NULL`, pero las entidades Kotlin tienen propiedades non-nullable. Room valida el esquema post-migración y lanza:

```
IllegalStateException: Migration didn't properly handle: user
```

## Cambios

1. **`MIGRATION_1_2`**: agrega `NOT NULL` a todas las columnas de las 3 tablas
2. **Nueva `MIGRATION_2_3` (v2 → v3)**: recrea `user`, `une` y `notifications` con `NOT NULL` para usuarios que ya tienen v2 con columnas nullable (create → insert select → drop → rename)
3. **`AppModule`**: registra `MIGRATION_2_3` junto a `MIGRATION_1_2`
4. DB version bump: 2 → 3

## Closes

Closes #310