### PR TITLE
fix: drawer no navega al pulsar opciones

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/feature/main/MainActivity.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/main/MainActivity.kt
@@ -503,6 +503,7 @@ private fun DrawerContent(
                 header = section.header,
                 items = section.items,
                 currentRoute = currentRoute,
+                onItemClick = onItemClick,
             )
         }
 
@@ -520,6 +521,7 @@ private fun DrawerSection(
     header: String? = null,
     items: List<DrawerItem>,
     currentRoute: String?,
+    onItemClick: (DrawerAction) -> Unit,
 ) {
     header?.let {
         Text(
@@ -536,7 +538,7 @@ private fun DrawerSection(
             label = { Text(item.label) },
             icon = item.icon?.let { icon -> { Icon(icon, contentDescription = null) } },
             selected = isSelected,
-            onClick = { item.onClick() },
+            onClick = { onItemClick(item.onClick()) },
             modifier = Modifier.padding(horizontal = 12.dp),
         )
     }


### PR DESCRIPTION
## Problema

El drawer lateral no responde a los clics. Las opciones no navegan, no abren URLs, no cierran el drawer.

## Causa

`DrawerSection` llama a `item.onClick()` que devuelve un `DrawerAction`, pero el resultado se descarta. El callback `onItemClick` de `MainScreen` nunca se ejecuta.

## Cambios

1. `DrawerSection` acepta `onItemClick: (DrawerAction) -> Unit`
2. El `onClick` del `NavigationDrawerItem` ahora llama `onItemClick(item.onClick())`
3. `DrawerContent` pasa `onItemClick` a `DrawerSection`

Closes #313