### PR TITLE
feat: mejorar diseño de MobileServicesScreen

### DIFF
--- a/app/src/main/java/com/marlon/portalusuario/feature/main/Navigation.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/main/Navigation.kt
@@ -76,7 +76,11 @@ fun PortalUsuarioNavHost(
                 },
             )
         }
-        composable(Route.Main.route) { MobileServicesScreen() }
+        composable(Route.Main.route) {
+            MobileServicesScreen(
+                onNavigateToServicios = { navController.navigate(Route.Servicios.route) },
+            )
+        }
         composable(Route.Settings.route) { SettingsScreen() }
         composable(Route.About.route) { AboutScreen() }
         composable(Route.Donation.route) { DonationScreen() }
@@ -100,7 +104,11 @@ fun PortalUsuarioNavHost(
         }
         composable(Route.Paquetes.route) { PaquetesScreen() }
         composable(Route.LogFileViewer.route) { LogFileViewerScreen() }
-        composable(Route.MobileServices.route) { MobileServicesScreen() }
+        composable(Route.MobileServices.route) {
+            MobileServicesScreen(
+                onNavigateToServicios = { navController.navigate(Route.Servicios.route) },
+            )
+        }
         composable(
             route = Route.PUNotifications.route,
             arguments =

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/BalanceSection.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/BalanceSection.kt
@@ -1,7 +1,6 @@
 package com.marlon.portalusuario.feature.mobileservices.presentation.components
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,25 +8,28 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.Send
-import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.marlon.portalusuario.R
+import com.marlon.portalusuario.core.theme.BrightOrange
 import com.marlon.portalusuario.core.theme.PortalUsuarioTheme
-import com.marlon.portalusuario.core.theme.TealBlue
+import com.marlon.portalusuario.core.theme.VibrantGreen
+import com.marlon.portalusuario.core.theme.VividRed
 import io.github.suitetecsa.sdk.android.utils.asDate
 import org.ocpsoft.prettytime.PrettyTime
 
@@ -37,68 +39,121 @@ fun BalanceSection(
     balanceCredit: String = "1500.00 CUP",
     lockDate: String = "31/11/2024",
     deletionDate: String = "31/12/2024",
-    isSimPaired: Boolean = false,
-    onAddBalance: () -> Unit = {},
-    onSendBalance: () -> Unit = {},
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    val lockDays = computeRemainingDays(lockDate)
+    val deletionDays = computeRemainingDays(deletionDate)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(id = R.string.balance_credit),
-            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-        )
-        Text(
-            text = balanceCredit,
-            style =
-                MaterialTheme.typography.titleLarge.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 32.sp,
-                ),
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(text = stringResource(id = R.string.expires, PrettyTime().format(lockDate.replace("/", "-").asDate)))
-        Text(
-            text =
-                stringResource(
-                    id = R.string.elimination,
-                    PrettyTime().format(deletionDate.replace("/", "-").asDate),
-                ),
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        if (isSimPaired) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(id = R.string.balance_credit),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = balanceCredit,
+                style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(16.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically,
             ) {
-                IconButton(
-                    onClick = onAddBalance,
-                    modifier = Modifier.background(TealBlue, shape = MaterialTheme.shapes.small),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Add,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.background,
-                    )
-                }
-                IconButton(
-                    onClick = onSendBalance,
-                    modifier = Modifier.background(TealBlue, shape = MaterialTheme.shapes.small),
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.Send,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.background,
-                    )
-                }
+                DateLabel(
+                    label = stringResource(id = R.string.expires, "").substringBefore("%"),
+                    date = formatDate(lockDate),
+                    remainingDays = lockDays,
+                )
+                HorizontalDivider(
+                    modifier = Modifier.height(40.dp).width(1.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+                DateLabel(
+                    label = stringResource(id = R.string.elimination, "").substringBefore("%"),
+                    date = formatDate(deletionDate),
+                    remainingDays = deletionDays,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun DateLabel(
+    label: String,
+    date: String,
+    remainingDays: Int,
+) {
+    val color = dateColor(remainingDays)
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = date,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = color,
+        )
+        Text(
+            text = remainingDaysText(remainingDays),
+            style = MaterialTheme.typography.labelSmall,
+            color = color.copy(alpha = 0.7f),
+        )
+    }
+}
+
+private fun computeRemainingDays(dateStr: String): Int {
+    return try {
+        val date = dateStr.replace("/", "-").asDate
+        val now = System.currentTimeMillis()
+        val diff = date!!.time - now
+        (diff / (1000 * 60 * 60 * 24)).toInt()
+    } catch (_: Exception) {
+        Int.MAX_VALUE
+    }
+}
+
+private fun formatDate(dateStr: String): String {
+    return try {
+        val date = dateStr.replace("/", "-").asDate
+        PrettyTime().format(date)
+    } catch (_: Exception) {
+        dateStr
+    }
+}
+
+private fun dateColor(remainingDays: Int): Color {
+    return when {
+        remainingDays < 0 -> VividRed
+        remainingDays < 7 -> VividRed
+        remainingDays < 30 -> BrightOrange
+        else -> VibrantGreen
+    }
+}
+
+private fun remainingDaysText(remainingDays: Int): String {
+    return when {
+        remainingDays < 0 -> "Vencido"
+        remainingDays == 0 -> "Hoy"
+        remainingDays == 1 -> "1 día"
+        remainingDays < 30 -> "$remainingDays días"
+        else -> "+30 días"
     }
 }
 
@@ -106,8 +161,6 @@ fun BalanceSection(
 @Composable
 private fun BalanceCardPreview() {
     PortalUsuarioTheme {
-        Surface(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
-            BalanceSection(modifier = Modifier.padding(16.dp), isSimPaired = true)
-        }
+        BalanceSection(modifier = Modifier.padding(16.dp))
     }
 }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/BonusSection.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/BonusSection.kt
@@ -47,7 +47,6 @@ internal fun BonusSection(bonuses: List<MobileBonus>) {
                 planTitle = it.type,
                 dataCount = it.data,
                 remainingDays = StringUtils.toDateMillis(it.expires.replace("/", "-")).asRemainingDays,
-                color = TropicalAquamarineGreen,
             )
         }
     }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/MobileServiceSelector.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/MobileServiceSelector.kt
@@ -10,10 +10,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,16 +23,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.marlon.portalusuario.domain.model.MobileBonus
-import com.marlon.portalusuario.domain.model.MobilePlan
-import com.marlon.portalusuario.domain.model.MobileService
-import com.marlon.portalusuario.domain.model.ServiceType
 import com.marlon.portalusuario.core.components.PrettyCard
 import com.marlon.portalusuario.core.components.Spinner
 import com.marlon.portalusuario.core.theme.BrightCoralRed
 import com.marlon.portalusuario.core.theme.PortalUsuarioTheme
 import com.marlon.portalusuario.core.theme.TealBlue
 import com.marlon.portalusuario.core.util.Utils.fixDateFormat
+import com.marlon.portalusuario.domain.model.MobileBonus
+import com.marlon.portalusuario.domain.model.MobilePlan
+import com.marlon.portalusuario.domain.model.MobileService
+import com.marlon.portalusuario.domain.model.ServiceType
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 @Composable
@@ -42,11 +44,13 @@ fun MobileServiceSelector(
     onShowServiceSettings: () -> Unit = {},
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        PrettyCard(modifier = Modifier.padding(horizontal = 16.dp)) {
+        PrettyCard(modifier = Modifier.weight(1f)) {
             Spinner(
                 items = services,
                 selectedItem = serviceSelected,
@@ -55,8 +59,8 @@ fun MobileServiceSelector(
                 dropdownItemFactory = { item, _ -> ServiceItem(item, simCards) },
             )
         }
-
-        PrettyCard(modifier = Modifier.padding(16.dp)) {
+        Spacer(modifier = Modifier.width(8.dp))
+        PrettyCard(modifier = Modifier.padding(0.dp)) {
             IconButton(onClick = onShowServiceSettings) {
                 Icon(imageVector = Icons.Outlined.Settings, contentDescription = null)
             }
@@ -73,17 +77,24 @@ private fun ServiceItem(
 ) {
     val simCard = simCards.firstOrNull { it.slotIndex == item.slotIndex }
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        Box(modifier = Modifier.background(simCard?.let { TealBlue } ?: BrightCoralRed)) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = simCard?.let { TealBlue } ?: BrightCoralRed,
+                    shape = RoundedCornerShape(4.dp),
+                ),
+        ) {
             Text(
                 text =
                     simCard?.let { sim ->
                         sim.displayName?.let { "$it (SIM ${sim.slotIndex + 1})" }
                             ?: "SIM ${sim.slotIndex + 1}"
                     } ?: "No SIM",
-                modifier = Modifier.padding(8.dp),
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                color = MaterialTheme.colorScheme.background,
             )
         }
-        Spacer(modifier = Modifier.width(4.dp))
+        Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = item.phoneNumber,
             modifier = Modifier.padding(8.dp),

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/PlanCard.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/PlanCard.kt
@@ -15,7 +15,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.marlon.portalusuario.core.components.ArcProgressbar
 import com.marlon.portalusuario.core.components.PrettyCard
-import com.marlon.portalusuario.core.theme.VibrantPink
+import com.marlon.portalusuario.core.theme.BrightOrange
+import com.marlon.portalusuario.core.theme.VibrantGreen
+import com.marlon.portalusuario.core.theme.VividRed
 
 @Composable
 fun PlanCard(
@@ -23,9 +25,10 @@ fun PlanCard(
     planTitle: String = "Data",
     dataCount: String = "3.50 GB + 4.50 GB",
     remainingDays: Int? = null,
-    color: Color = VibrantPink,
     isDailyData: Boolean = false,
 ) {
+    val color = progressColor(remainingDays, 30)
+
     PrettyCard(modifier = modifier) {
         Column(
             modifier = Modifier.padding(4.dp),
@@ -49,6 +52,15 @@ fun PlanCard(
             )
             Text(text = dataCount)
         }
+    }
+}
+
+private fun progressColor(remainingDays: Int?, maxDays: Int): Color {
+    val ratio = if (remainingDays != null && maxDays > 0) remainingDays.toFloat() / maxDays else 1f
+    return when {
+        ratio > 0.5f -> VibrantGreen
+        ratio > 0.16f -> BrightOrange
+        else -> VividRed
     }
 }
 

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/PlansSection.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/components/PlansSection.kt
@@ -79,7 +79,6 @@ internal fun PlansSection(
                     planTitle = it.type,
                     dataCount = it.data,
                     remainingDays = it.expires.asDateMillis?.asRemainingDays,
-                    color = VibrantTangerineOrange,
                 )
             }
         }

--- a/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreen.kt
+++ b/app/src/main/java/com/marlon/portalusuario/feature/mobileservices/presentation/screen/MobileServicesScreen.kt
@@ -1,22 +1,37 @@
 package com.marlon.portalusuario.feature.mobileservices.presentation.screen
 
 import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.marlon.portalusuario.core.components.EmptyState
+import com.marlon.portalusuario.core.components.ErrorDialog
+import com.marlon.portalusuario.core.components.PrettyCard
+import com.marlon.portalusuario.core.theme.PortalUsuarioTheme
+import com.marlon.portalusuario.domain.model.MobServPreferences
 import com.marlon.portalusuario.domain.model.MobileService
+import com.marlon.portalusuario.domain.model.ServiceType
 import com.marlon.portalusuario.feature.mobileservices.presentation.MobileServicesEvent
 import com.marlon.portalusuario.feature.mobileservices.presentation.MobileServicesEvent.OnHideSImCardsSettings
 import com.marlon.portalusuario.feature.mobileservices.presentation.MobileServicesEvent.OnHideServiceSettings
@@ -29,49 +44,106 @@ import com.marlon.portalusuario.feature.mobileservices.presentation.components.M
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.PlansSection
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.configsimcards.ConfigSimCardsBottomSheet
 import com.marlon.portalusuario.feature.mobileservices.presentation.components.servsettings.ServiceSettingsBottomSheet
-import com.marlon.portalusuario.core.components.EmptyState
-import com.marlon.portalusuario.core.components.ErrorDialog
 import io.github.suitetecsa.sdk.android.model.SimCard
 
 private const val TAG = "MobileServicesScreen"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MobileServicesScreen(viewModel: MobileServicesViewModel = hiltViewModel()) {
+fun MobileServicesScreen(
+    onNavigateToServicios: () -> Unit = {},
+    viewModel: MobileServicesViewModel = hiltViewModel(),
+) {
     val mobServices by viewModel.mobileServices.collectAsStateWithLifecycle()
     val preferences by viewModel.preferences.collectAsStateWithLifecycle()
 
-    Log.d(TAG, "MobileServicesScreen: ${viewModel.simCards}")
+    MobileServicesScreen(
+        mobServices = mobServices,
+        preferences = preferences,
+        state = viewModel.state.value,
+        simCards = viewModel.simCards,
+        onEvent = viewModel::onEvent,
+        onNavigateToServicios = onNavigateToServicios,
+    )
+}
 
-    PullToRefreshBox(
-        isRefreshing = viewModel.state.value.isLoading,
-        onRefresh = { viewModel.onEvent(MobileServicesEvent.OnUpdate) },
-        modifier =
-            Modifier
-                .fillMaxSize(),
-    ) {
-        if (mobServices.isEmpty()) {
-            EmptyState(message = "No hay servicios móviles disponibles")
-        } else {
-            val serviceId =
-                preferences.mssId ?: mobServices.first().id.also {
-                    viewModel.onEvent(MobileServicesEvent.OnChangeCurrentMobileService(it))
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MobileServicesScreen(
+    mobServices: List<MobileService>,
+    preferences: MobServPreferences,
+    state: MobileServicesState,
+    simCards: List<SimCard>,
+    onEvent: (MobileServicesEvent) -> Unit,
+    onNavigateToServicios: () -> Unit = {},
+) {
+    Log.d(TAG, "MobileServicesScreen: $simCards")
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        PullToRefreshBox(
+            isRefreshing = state.isLoading,
+            onRefresh = { onEvent(MobileServicesEvent.OnUpdate) },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            when {
+                mobServices.isEmpty() && state.isLoading -> LoadingSkeleton()
+                mobServices.isEmpty() -> EmptyState(message = "No hay servicios móviles disponibles")
+                else -> {
+                    val serviceId =
+                        preferences.mssId ?: mobServices.first().id.also {
+                            onEvent(MobileServicesEvent.OnChangeCurrentMobileService(it))
+                        }
+                    ScreenContent(
+                        services = mobServices,
+                        currentServiceId = serviceId,
+                        state = state,
+                        onEvent = onEvent,
+                        simCards = simCards,
+                    )
                 }
-            ScreenContent(
-                services = mobServices,
-                currentServiceId = serviceId,
-                state = viewModel.state.value,
-                onEvent = viewModel::onEvent,
-                simCards = viewModel.simCards,
-            )
+            }
+
+            if (state.isSimCardsSettingsVisible) {
+                ConfigSimCardsBottomSheet(onDismiss = { onEvent(OnHideSImCardsSettings) })
+            }
+
+            state.error?.let {
+                ErrorDialog(it) { onEvent(MobileServicesEvent.OnErrorDismiss) }
+            }
         }
 
-        if (viewModel.state.value.isSimCardsSettingsVisible) {
-            ConfigSimCardsBottomSheet(onDismiss = { viewModel.onEvent(OnHideSImCardsSettings) })
+        if (mobServices.isNotEmpty()) {
+            FloatingActionButton(
+                onClick = onNavigateToServicios,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+                shape = RoundedCornerShape(16.dp),
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Recargar")
+            }
         }
+    }
+}
 
-        viewModel.state.value.error?.let {
-            ErrorDialog(it) { viewModel.onEvent(MobileServicesEvent.OnErrorDismiss) }
+@Composable
+private fun LoadingSkeleton() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        PrettyCard(isLoading = true) {
+            Spacer(modifier = Modifier.height(48.dp).fillMaxSize())
+        }
+        PrettyCard(isLoading = true) {
+            Spacer(modifier = Modifier.height(160.dp).fillMaxSize())
+        }
+        PrettyCard(isLoading = true) {
+            Spacer(modifier = Modifier.height(140.dp).fillMaxSize())
         }
     }
 }
@@ -85,37 +157,86 @@ fun ScreenContent(
     simCards: List<SimCard> = listOf(),
 ) {
     val service = services.first { it.id == currentServiceId }
-    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-        MobileServiceSelector(
-            services = services,
-            serviceSelected = service,
-            onServiceSelected = { onEvent(MobileServicesEvent.OnChangeCurrentMobileService(it.id)) },
-            simCards = simCards,
-            onShowServiceSettings = { onEvent(OnShowServiceSettings) },
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        BalanceSection(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            balanceCredit = "${service.mainBalance} ${service.currency}",
-            lockDate = service.lockDate,
-            deletionDate = service.deletionDate,
-            isSimPaired = service.slotIndex != -1,
-            onAddBalance = { /*TODO*/ },
-            onSendBalance = { /*TODO*/ },
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        PlansSection(plans = service.plans)
-        service.bonuses.takeIf { it.isNotEmpty() }?.let {
-            Spacer(modifier = Modifier.height(8.dp))
-            BonusSection(bonuses = it)
+
+    LazyColumn(
+        contentPadding = PaddingValues(top = 4.dp, bottom = 80.dp),
+    ) {
+        item {
+            MobileServiceSelector(
+                services = services,
+                serviceSelected = service,
+                onServiceSelected = { onEvent(MobileServicesEvent.OnChangeCurrentMobileService(it.id)) },
+                simCards = simCards,
+                onShowServiceSettings = { onEvent(OnShowServiceSettings) },
+            )
         }
-        Spacer(modifier = Modifier.height(32.dp))
+        item {
+            Spacer(modifier = Modifier.height(4.dp))
+            BalanceSection(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                balanceCredit = "${service.mainBalance} ${service.currency}",
+                lockDate = service.lockDate,
+                deletionDate = service.deletionDate,
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            PlansSection(plans = service.plans)
+        }
+        if (service.bonuses.isNotEmpty()) {
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                BonusSection(bonuses = service.bonuses)
+            }
+        }
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
     }
 
     if (state.isServiceSettingsVisible) {
         ServiceSettingsBottomSheet(
             mobService = service,
             onDismiss = { onEvent(OnHideServiceSettings) },
+        )
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+fun MobileServicesScreenPreview() {
+    PortalUsuarioTheme {
+        MobileServicesScreen(
+            mobServices =
+                listOf(
+                    MobileService(
+                        id = "service1",
+                        lte = false,
+                        advanceBalance = "0.00",
+                        status = "Active",
+                        lockDate = "2023-12-31",
+                        deletionDate = "2024-01-30",
+                        saleDate = "",
+                        internet = true,
+                        plans = emptyList(),
+                        bonuses = emptyList(),
+                        currency = "CUP",
+                        phoneNumber = "52345678",
+                        mainBalance = "100.00",
+                        consumptionRate = false,
+                        slotIndex = 0,
+                        type = ServiceType.Remote,
+                        lastUpdated = System.currentTimeMillis(),
+                    ),
+                ),
+            preferences =
+                MobServPreferences(
+                    slotIndexInfoList = emptyList(),
+                    mssId = "service1",
+                ),
+            state = MobileServicesState(),
+            simCards = emptyList(),
+            onEvent = {},
         )
     }
 }


### PR DESCRIPTION
## Cambios

### BalanceSection (rediseño completo)
- Hero card con Card de Material3, sombra y bordes redondeados (16dp)
- Saldo en `displaySmall` bold con color primario
- Fechas con código de color semáforo: verde (>30d), naranja (7-30d), rojo (<7d o vencido)
- Indicador de días restantes debajo de cada fecha
- Eliminados botones Add/Send balance (estaban implementados como TODO)

### ScreenContent → LazyColumn
- Reemplazado `Column + Modifier.verticalScroll` por `LazyColumn`
- Elimina el conflicto gestual entre el scroll vertical y los `LazyRow` de Planes/Bonos

### LoadingSkeleton
- Tres PrettyCard con `isLoading = true` simulando el layout real mientras carga

### PlanCard
- Color del arco de progreso dinámico según `remainingDays / 30`:
  - \>50% → VibrantGreen
  - 16-50% → BrightOrange
  - <16% → VividRed
- Eliminado parámetro `color` (ahora se calcula internamente)

### MobileServiceSelector
- `Row` con `fillMaxWidth` y `Arrangement.SpaceBetween`
- Spinner con `Modifier.weight(1f)` para evitar desbordamiento
- Badge SIM con `RoundedCornerShape(4.dp)` y texto en `background`

### FAB de recarga rápida
- `FloatingActionButton` alineado bottom-end
- Navega a `Route.Servicios`
- Padding inferior de 80dp en LazyColumn para no solapar contenido

### Navigation.kt
- Pasado `onNavigateToServicios` a MobileServicesScreen en rutas Main y MobileServices

## Archivos modificados
- `MobileServicesScreen.kt`
- `BalanceSection.kt`
- `PlanCard.kt`
- `MobileServiceSelector.kt`
- `PlansSection.kt` (remove color param)
- `BonusSection.kt` (remove color param)
- `Navigation.kt`

Closes #315